### PR TITLE
Add a link for Slack discussion group

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
 
 <p>Join the mailing list: <a href="https://groups.google.com/forum/#!forum/sonicproject">https://groups.google.com/forum/#!forum/sonicproject</a></p>
 
-<p>Join the Slack discussion group: sonicswitch.slack.com</p>
+<p>Join the Slack discussion group: <a href="https://sonicswitch.slack.com/">sonicswitch.slack.com</p>
 
         </section>
 


### PR DESCRIPTION
Added a direct link for Slack discussion group for more comfortable UX