### PR TITLE
add <img> tag for sonic logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <body>
     <div id="container">
       <div class="inner">
-
+         <img src="https://github.com/Azure/SONiC/blob/master/images/sonic-logo.png">
         <header>
           <h1>Software for Open Networking in the Cloud</h1>
           <h1>SONiC</h1>


### PR DESCRIPTION
add the sonic logo to the landing page.  This commit depends on a previous pull request to add the sonic logo to the images directory.  Let's approve and merge that one first, then we can mess with this one more.