### PR TITLE
Rif counters design

### DIFF
--- a/doc/RIF_counters.md
+++ b/doc/RIF_counters.md
@@ -226,12 +226,3 @@ Example virtual paths
 | COUNTERS_DB	| "RIF_COUNTERS/``<interface name>``/``<counter name>``" |	One counter on one interface |
 
 ### 4 Open questions
-
-#### 4.1 SNMP support?
-
- - is SNMP support needed?
- - Which MIB to use?
- 
-Inreface MIB (RFC1213) has some issues:
-  - already provides l2 counters for Ethernet*, adding l3 overlaps, no separate iftype
-  - Interface MIB has more specific OIDs. it contains OIDs for InUnicast / InMcast pkts; eroor, drop pkts, while rif counters only have InPkts, error packets. 


### PR DESCRIPTION
Open for discussion

Add new CLI commands to show L3 interfaces counters. L3 interface counters refers to router port as well as vlan interface.
The information should be: RX: OK, ERR in packets and bytes. TX: OK, ERR in packets and bytes 