### PR TITLE
OCP2019 Sonic video added

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,8 +234,8 @@
           </div>
           <div class="col-lg-6 col-md-6">
             <div class="mu-about-us-right"> 
-				<h3 style="color: #01BAFD; margin-top: 50px; font-weight: bold"> SONiC Video From OCP Summit 2018</h3>
-				<iframe width="80%" height="280.35" src="https://www.youtube.com/embed/TLi5n0cZbz0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>				
+				<h3 style="color: #01BAFD; margin-top: 50px; font-weight: bold"> SONiC Video From OCP Summit 2019</h3>
+				<iframe width="80%" height="280.35" src="https://www.youtube.com/embed/7ZlbHIkgFRQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>				
             </div>
           </div>
         </div>
@@ -266,6 +266,11 @@
               <div class="col-lg-6 col-md-6">
                 <div class="mu-about-us-right">
 				<h3 style="color: #01BAFD; margin-top: 70px; font-weight: bold">More Presentations</h3>
+				    <p>
+					  <a href="https://www.youtube.com/embed/TLi5n0cZbz0"> 
+					  SONiC Video From OCP Summit 2018
+					  </a>
+				    </p>				
 				    <p>
 					  <a href="https://github.com/Azure/SONiC/wiki/SONiC-Workshop-in-Beijing-Oct-2018"> 
 					  SONiC Workshop in Beijing 2018 October


### PR DESCRIPTION
1) Changed the video link from 2018 to 2019. New video is from https://www.youtube.com/watch?v=7ZlbHIkgFRQ
2) A new link added in "More presentations" and moved the 2018 video link here.