### PR TITLE
[Doc] Update nexthop seperator to "@" in vrf_ansible_test_plan

### DIFF
--- a/doc/vrf/vrf-ansible-test-plan.md
+++ b/doc/vrf/vrf-ansible-test-plan.md
@@ -383,12 +383,12 @@ Acl redirect action supports vrf, so we need specify the outgoing interface of t
         "VRF_ACL_REDIRECT_V4|rule1": {
             "priority": "55",
             "SRC_IP": "10.0.0.1",
-            "packet_action": "redirect:{\% for intf, ip in redirect_dst_ipv6s \%}{{ ip ~ "|" ~ intf }}{{ "," if not loop.last else "" }}{\% endfor \%}"
+            "packet_action": "redirect:{\% for intf, ip in redirect_dst_ipv6s \%}{{ ip ~ "@" ~ intf }}{{ "," if not loop.last else "" }}{\% endfor \%}"
         },
         "VRF_ACL_REDIRECT_V6|rule1": {
             "priority": "55",
             "SRC_IPV6": "2000::1",
-            "packet_action": "redirect:{\% for intf, ip in redirect_dst_ipv6s \%}{{ ip ~ "|" ~ intf }}{{ "," if not loop.last else "" }}{\% endfor \%}"
+            "packet_action": "redirect:{\% for intf, ip in redirect_dst_ipv6s \%}{{ ip ~ "@" ~ intf }}{{ "," if not loop.last else "" }}{\% endfor \%}"
         }
     }
 }


### PR DESCRIPTION
According to VRF latest [implementation](https://github.com/Azure/sonic-swss/pull/977), the seperator of nexthop changed from "|" to "@"