### PR TITLE
[sonic_platform_test_plan.md] Move system EEPROM tests to their own section

### DIFF
--- a/doc/pmon/sonic_platform_test_plan.md
+++ b/doc/pmon/sonic_platform_test_plan.md
@@ -1,18 +1,19 @@
 - [Introduction](#introduction)
 - [Common Test Cases](#common-test-cases)
   - [1.1 Check platform information](#11-check-platform-information)
-  - [1.2 Run the Sensors automation](#12-run-the-sensors-automation)
-  - [1.3 Check SFP status and configure SFP](#13-check-sfp-status-and-configure-sfp)
-  - [1.4 Check xcvrd information in DB](#14-check-xcvrd-information-in-db)
-  - [1.5 Sequential syncd/swss restart](#15-sequential-syncdswss-restart)
-  - [1.6 Reload configuration](#16-reload-configuration)
-  - [1.7 COLD/WARM/FAST/POWER OFF/WATCHDOG reboot](#17-coldwarmfastpower-offwatchdog-reboot)
-  - [1.8 Check thermal sensors output using new OPTIC cables](#18-check-thermal-sensors-output-using-new-optic-cables)
-  - [1.9 Manually plug in and pull out PSU modules](#19-manually-plug-in-and-pull-out-psu-modules)
-  - [1.10 Manually plug in and pull out PSU power cord](#110-manually-plug-in-and-pull-out-psu-power-cord)
-  - [1.11 Manually plug in and pull out FAN modules](#111-manually-plug-in-and-pull-out-fan-modules)
-  - [1.12 Manually plug in and pull out optical cables](#112-manually-plug-in-and-pull-out-optical-cables)
-  - [1.13 Check platform daemon status](#113-check-platform-daemon-status)
+  - [1.2 Check System EEPROM](#12-check-system-eeprom)
+  - [1.3 Run the Sensors automation](#13-run-the-sensors-automation)
+  - [1.4 Check SFP status and configure SFP](#14-check-sfp-status-and-configure-sfp)
+  - [1.5 Check xcvrd information in DB](#15-check-xcvrd-information-in-db)
+  - [1.6 Sequential syncd/swss restart](#16-sequential-syncdswss-restart)
+  - [1.7 Reload configuration](#17-reload-configuration)
+  - [1.8 COLD/WARM/FAST/POWER OFF/WATCHDOG reboot](#18-coldwarmfastpower-offwatchdog-reboot)
+  - [1.9 Check thermal sensors output using new OPTIC cables](#19-check-thermal-sensors-output-using-new-optic-cables)
+  - [1.10 Manually plug in and pull out PSU modules](#110-manually-plug-in-and-pull-out-psu-modules)
+  - [1.11 Manually plug in and pull out PSU power cord](#111-manually-plug-in-and-pull-out-psu-power-cord)
+  - [1.12 Manually plug in and pull out FAN modules](#112-manually-plug-in-and-pull-out-fan-modules)
+  - [1.13 Manually plug in and pull out optical cables](#113-manually-plug-in-and-pull-out-optical-cables)
+  - [1.14 Check platform daemon status](#114-check-platform-daemon-status)
 - [Mellanox Specific Test Cases](#mellanox-specific-test-cases)
   - [2.1 Ensure that the hw-management service is running properly](#21-ensure-that-the-hw-management-service-is-running-properly)
   - [2.2 Check SFP using ethtool](#22-check-sfp-using-ethtool)
@@ -56,6 +57,32 @@ In common test cases, some steps are platform dependent. Detailed information wi
 
 * Run `show platform summary`
 * Turn off/on PSU from PDU (Power Distribution Unit), run `show platform psustatus` respectively. In automation, PDU with programmable interface is required for turning off/on PSU. Without PDU, manual intervention required for this step.
+
+### Pass/Fail Criteria
+
+* `show platform summary` should output these fields: Platform, HwSKU, ASIC, for example:
+```
+admin@mtbc-sonic-03-2700:~$ show platform summary
+Platform: x86_64-mlnx_msn2700-r0
+HwSKU: ACS-MSN2700
+ASIC: mellanox
+```
+* PSU status should be `OK` when it is on, `NOT OK` when it is off. Use PDU to turn off/on PSU to verify that correct PSU status can be displayed.
+```
+admin@mtbc-sonic-03-2700:~$ show platform psustatus
+PSU    Status
+-----  --------
+PSU 1  NOT OK
+PSU 2  OK
+```
+### Automation
+New automation required.
+The step for turning on/off PSU needs programmable PDU. Need to implement a fixture for turning on/off PSU. When programmable PDU is not available in testbed, this step can only be tested manually. The fixture should be able to return information about whether this capability is supported. If not supported, skip this step in automation.
+
+## 1.2 Check System EEPROM
+
+### Steps
+
 * Run `show platform syseeprom`
 * Use the platform specific eeprom.py utility to directly decode eeprom information from hardware, compare the result with output of cmd `show platform syseeprom`. **This step is platform dependent.** Different eeprom.py utility should be used on different platforms. The below example is taken from Mellanox platform.
 ```
@@ -95,21 +122,6 @@ CRC-32               0xFE   4 0x371DD10F
 
 ### Pass/Fail Criteria
 
-* `show platform summary` should output these fields: Platform, HwSKU, ASIC, for example:
-```
-admin@mtbc-sonic-03-2700:~$ show platform summary
-Platform: x86_64-mlnx_msn2700-r0
-HwSKU: ACS-MSN2700
-ASIC: mellanox
-```
-* PSU status should be `OK` when it is on, `NOT OK` when it is off. Use PDU to turn off/on PSU to verify that correct PSU status can be displayed.
-```
-admin@mtbc-sonic-03-2700:~$ show platform psustatus
-PSU    Status
------  --------
-PSU 1  NOT OK
-PSU 2  OK
-```
 * The syseeprom information should have format as the example:
 ```
 admin@mtbc-sonic-03-2700:~$ show platform syseeprom
@@ -140,10 +152,9 @@ CRC-32               0xFE   4 0x371DD10F
 * The syseeprom info output from cmd `show platform syseeprom` should comply with the info decoded using platform specific eeprom.py utility.
 
 ### Automation
-New automation required.
-The step for turning on/off PSU needs programmable PDU. Need to implement a fixture for turning on/off PSU. When programmable PDU is not available in testbed, this step can only be tested manually. The fixture should be able to return information about whether this capability is supported. If not supported, skip this step in automatin.
+Covered by existing automation
 
-## 1.2 Run the Sensors automation
+## 1.3 Run the Sensors automation
 
 ### Steps
 * Run the sensors automation to ensure that it PASS.
@@ -161,7 +172,7 @@ The script should PASS
 ### Automation
 Covered by existing automation. In the future, this script could be converted to pytest based code.
 
-## 1.3 Check SFP status and configure SFP
+## 1.4 Check SFP status and configure SFP
 
 This case is to use the sfputil tool and show command to check SFP status and configure SFP. Currently the the only configuration is to reset SFP.
   * `sfputil show presence`
@@ -222,7 +233,7 @@ Resetting port Ethernet0...  OK
 ### Automation
 New automation required
 
-## 1.4 Check xcvrd information in DB
+## 1.5 Check xcvrd information in DB
 This test case is to verify that xcvrd works as expected by checking transcever information in DB.
 
 ### Steps
@@ -301,7 +312,7 @@ admin@mtbc-sonic-03-2700:~$ redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|Ether
 ### Automation
 New automation required
 
-## 1.5 Sequential syncd/swss restart
+## 1.6 Sequential syncd/swss restart
 
 ### Steps
 * Restart the syncd and swss service:
@@ -330,7 +341,7 @@ New automation required
 ### Automation
 New automation required
 
-## 1.6 Reload configuration
+## 1.7 Reload configuration
 
 ### Steps
 * Reload configuration using: `config load_minigraph -y` and `config reload -y`
@@ -357,7 +368,7 @@ New automation required
 ### Automation
 Partly covered by existing automation. New automation required.
 
-## 1.7 COLD/WARM/FAST/POWER OFF/WATCHDOG reboot
+## 1.8 COLD/WARM/FAST/POWER OFF/WATCHDOG reboot
 
 ### Steps
 * Perform cold/warm/fast/power off/watchdog reboot
@@ -404,7 +415,7 @@ Partly covered by existing automation:
 
 Need to re-implement these scripts in pytest and cover the testing in this test case.
 
-## 1.8 Check thermal sensors output using new OPTIC cables
+## 1.9 Check thermal sensors output using new OPTIC cables
 
 ### Steps
 * Plug in new OPTIC cables
@@ -416,7 +427,7 @@ Need to re-implement these scripts in pytest and cover the testing in this test 
 ### Automation
 Manual intervention required, not automatable
 
-## 1.9 Manually plug in and pull out PSU modules
+## 1.10 Manually plug in and pull out PSU modules
 
 This test case needs to frequently check various status, the status to be checked and commands for checking them:
 * status of services: syncd, swss:
@@ -457,7 +468,7 @@ Expected results of checking varous status:
 ### Automation
 Manual intervention required, not automatable
 
-## 1.10 Manually plug in and pull out PSU power cord
+## 1.11 Manually plug in and pull out PSU power cord
 
 This test case needs to frequently check various status, the status to be checked and commands for checking them:
 * status of services: syncd, swss:
@@ -498,7 +509,7 @@ Expected results of checking varous status:
 ### Automation
 Manual intervention required, not automatable
 
-## 1.11 Manually plug in and pull out FAN modules
+## 1.12 Manually plug in and pull out FAN modules
 
 This test case needs to frequently check various status, the status to be checked and commands for checking them:
 * status of services: syncd, swss:
@@ -539,7 +550,7 @@ Expected results of checking varous status:
 ### Automation
 Manual intervention required, not automatable
 
-## 1.12 Manually plug in and pull out optical cables
+## 1.13 Manually plug in and pull out optical cables
 
 This test case needs to frequently check various status, the status to be checked and commands for checking them:
 * status of services: syncd, swss:
@@ -580,7 +591,7 @@ Expected results of checking varous status:
 ### Automation
 Manual intervention required, not automatable
 
-## 1.13 Check platform daemon status
+## 1.14 Check platform daemon status
 
 This test case will check the all daemon running status inside pmon(ledd no included) if they are supposed to to be running on this platform.
 * Using command `docker exec pmon supervisorctl status | grep {daemon}` to get the status of the daemon


### PR DESCRIPTION
Move system EEPROM tests out from platform information section into their own section, in order to better organize tests by the component to be tested.

As the "platform_info" suite of tests rely on calling the related SONiC `show` commands, I believe we may want to move these files into a `cli/` subdirectory, and organize the files by the subgroups/subcommands they test. This way, we will have an `api/` subdirectory which contains tests which test the platform API directly, and a `cli/` which contains tests which test the platform functionality via the SONiC CLI.