### PR TITLE
Add reboot-cause information to telemetry

### DIFF
--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -14,7 +14,7 @@
 #### Part 1
 During the boot, the `determine-reboot-cause` service ( previously `process-reboot-cause`) determines the last reboot-cause based on the hardware reboot-cause
 and the software reboot-cause information and creates previous-reboot-cause.txt with the information as it does currently.
-In addition, to save the history of the previous reboot-cause, `determine-reboot-cause` will save the previous
+In addition, to save the history of the previous reboot-cause, `determine-reboot-cause` service will save the previous
 reboot cause information to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp at the end of file name.
 And the file will be formatted to be parsed easily.
 
@@ -48,7 +48,7 @@ admin@sonic:~$ sudo cat /host/reboot-cause/previous-reboot-cause/previous-reboot
 #### Part 2
 A new service named as `process-reboot-cause.service` which will retrieve the saved reboot-cause files and read each reboot-cause information from the files
 and save the reboot-cause information up to 10 entries to state-DB.
-Verify the information from state-DB data is available via the cli command `show reboot-history` which is extended from `show reboot-cause`.
+Verify the information from state-DB data is available via the cli command `show reboot-cause history` which is extended from `show reboot-cause`.
 
 ##### Reboot Cause Schema in state-DB
 
@@ -69,7 +69,7 @@ comment                 = STRING                         ; unstructured json for
 
 Currently `show reboot-cause` displays the last reboot-cause and performing `cat /host/reboot-cause/previous-reboot-cause.txt` to show the reboot-cause.
 This will be same as current design.
-With new design, `show reboot-history` will be added to display the previous reboot-cause information up to 10 entries from state-DB.
+With new design, `show reboot-cause history` will be added to display the previous reboot-cause information up to 10 entries from state-DB.
 
 The example shows the output of `show reboot-cause` which is same as current output and displays only the last reboot-cause.
 ```
@@ -92,9 +92,9 @@ REBOOT_CAUSE|2020_10_09_04_53_58
 ""
 ```
 
-The example shows the output of `show reboot-history` and the previous reboot cause stored in state-DB in addition to the last reboot-cause.
+The example shows the output of `show reboot-cause history` and the previous reboot cause stored in state-DB in addition to the last reboot-cause.
 ```
-admin@sonic:~$ show reboot-history 
+admin@sonic:~$ show reboot-cause history
 name                 cause        time                          user    comment
 -------------------  -----------  ----------------------------  ------  ---------
 2020_10_09_04_53_58  warm-reboot  Fri Oct  9 04:51:47 UTC 2020  admin

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -20,16 +20,16 @@ reboot cause information to "/host/reboot-cause/previous-reboot-cause/" with add
 The example shows the previous reboot-cause files stored in /host/reboot-cause/previous-reboot-cause/.
 ```
 admin@sonic:~$ ls /host/reboot-cause/previous-reboot-cause/
-previous-reboot-cause-2020_10_09_01_56_59.txt
-previous-reboot-cause-2020_10_09_02_00_53.txt
-previous-reboot-cause-2020_10_09_02_33_06.txt
-previous-reboot-cause-2020_10_09_04_53_58.txt
+reboot-cause-2020_10_09_01_56_59.txt
+reboot-cause-2020_10_09_02_00_53.txt
+reboot-cause-2020_10_09_02_33_06.txt
+reboot-cause-2020_10_09_04_53_58.txt
 ...
 ```
 
-The following example shows the content of the previous reboot-cause file - previous-reboot-cause-2020_10_09_04_53_58.txt.
+The following example shows the content of the previous reboot-cause file - reboot-cause-2020_10_09_04_53_58.txt.
 ```
-admin@sonic:~$ sudo cat /host/reboot-cause/previous-reboot-cause/previous-reboot-cause-2020_10_09_04_53_58.txt
+admin@sonic:~$ sudo cat /host/reboot-cause/previous-reboot-cause/reboot-cause-2020_10_09_04_53_58.txt
 {"comment": "", "gen_time": "2020_10_09_04_53_58", "cause": "warm-reboot", "user": "admin", "time": "Fri Oct  9 04:51:47 UTC 2020"}
 ```
 ```

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -12,10 +12,11 @@
 ### Enable sonic streaming telemetry agent to send Reboot-cause information
 
 ##### Part 1 
-For 1st part, Daemon code will be added under sonic-buildimage/files/image_config.  A Daemon will start when OS starts. At every 2 min interval it will do following:  
-Delete all entries for Reboot-cause information from state db  
-Read Reboot-cause information from Reboot-cause history file
-Update Reboot-cause information upto 10 entries to state-DB.  
+For 1st part, process-reboot-cause copies the previous-reboot-cause.txt 
+to "/host/reboot-cause/previous_reboot-cause/" with adding timestamp 
+at the end of file name after processing the reboot-cause.
+Read each reboot-cause information from saved previous-reboot-cause files
+And update reboot-cause information upto 10 entries to state-DB.  
 
 Details of CLI and state-DB given below. 
 Cli command to retrieve the Reboot-cause information
@@ -60,7 +61,7 @@ REBOOT_CAUSE|4276
 "user"  
 "admin"  
 "comment"  
-""  
+"User issued 'reboot' command [User: admin, Time: Wed 02 Sep 2020 05:48:42 PM UTC]"  
 ```
 Hardware `Unknown` cause example : 
 ```
@@ -77,5 +78,5 @@ REBOOT_CAUSE|4170
 "user"  
 ""
 "comment"  
-"faults reg: 00 00 00 00 00 00 00 00 00 00 00 00 00 00"  
+"Unknown"
 ```

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -12,7 +12,7 @@
 ### Enable sonic streaming telemetry agent to send Reboot-cause information
 
 #### Part 1
-During the boot, the `determine-reboot-cause`(previously `process-reboot-cause`) determines the last reboot-cause based on the hardware reboot-cause
+During the boot, the `determine-reboot-cause` service ( previously `process-reboot-cause`) determines the last reboot-cause based on the hardware reboot-cause
 and the software reboot-cause information and creates previous-reboot-cause.txt with the information as it does currently.
 In addition, to save the history of the previous reboot-cause, `determine-reboot-cause` will save the previous
 reboot cause information to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp at the end of file name.

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -13,7 +13,7 @@
 
 #### Part 1
 During the boot, the `determine-reboot-cause` service ( previously `process-reboot-cause`) determines the last reboot-cause based on the hardware reboot-cause
-and the software reboot-cause information and `determine-reboot-cause` service will save the formatted last previous
+and the software reboot-cause information and `determine-reboot-cause` service will save the JSON-formatted last previous
 reboot cause information to "/host/reboot-cause/history/" with adding timestamp at the end of file name.
 `determine-reboot-cause` also will also create a symbolic link of the last reboot cause file to "/host/reboot-cause/previous-reboot-cause.json"
 

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -1,0 +1,81 @@
+# Reboot-cause information via telemetry agent
+
+## Revision
+
+| Rev | Date     | Author      | Change Description |
+|:---:|:--------:|:-----------:|--------------------|
+| 0.1 | 09/02/20 | Sujin Kang  | Initial version    |
+
+## Scope
+-Enable sonic streaming telemetry agent to send Reboot-cause information
+
+### Enable sonic streaming telemetry agent to send Reboot-cause information
+
+##### Part 1 
+For 1st part, Daemon code will be added under sonic-buildimage/files/image_config.  A Daemon will start when OS starts. At every 2 min interval it will do following:  
+Delete all entries for Reboot-cause information from state db  
+Read Reboot-cause information from Reboot-cause history file
+Update Reboot-cause information upto 10 entries to state-DB.  
+
+Details of CLI and state-DB given below. 
+Cli command to retrieve the Reboot-cause information
+```
+$ show reboot-cause
+```
+state-DB schema to store the Reboot-cause information
+```
+; Defines information for reboot-cause
+key                     = REBOOT_CAUSE|timestamp         ; last reboot-cause processing time
+; field                 = value
+cause                   = STRING                         ; last reboot cause
+time                    = STRING                         ; time when the last reboot was initiated
+user                    = STRING                         ; user who the last reboot initiated
+comment                 = STRING                         ; unstructured json format data
+```
+Along with data new entry for timestamp will be added up to 10 entries in state_db:  
+
+```
+REBOOT_CAUSE|timestamp
+```
+
+##### Part 2
+Verify that from state-DB data is available via telemetry agent
+
+##### CLI output  and corresponding structure in state-DB for reboot-cause information
+
+###### reboot-cause information
+
+Software User `reboot` cause example :
+```
+$ show reboot-cause
+User issued 'reboot' command [User: admin, Time: Wed 02 Sep 2020 05:48:42 PM UTC]
+```
+above output will be stored inside state-DB as follows for the reboot-cause information
+```
+REBOOT_CAUSE|4276  
+"cause"  
+"reboot"  
+"time"  
+"Wed 02 Sep 2020 05:48:42 PM UTC"  
+"user"  
+"admin"  
+"comment"  
+""  
+```
+Hardware `Unknown` cause example : 
+```
+$ show reboot-cause
+User issued 'reboot' command [User: admin, Time: Wed 02 Sep 2020 05:48:42 PM UTC]
+```
+above output will be stored inside state-DB as follows for the reboot-cause information
+```
+REBOOT_CAUSE|4170  
+"cause"  
+"Unknown"  
+"time"  
+""
+"user"  
+""
+"comment"  
+"faults reg: 00 00 00 00 00 00 00 00 00 00 00 00 00 00"  
+```

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -14,10 +14,9 @@
 #### Part 1
 During the boot, the process-reboot-cause processes the last reboot-cause based on the hardware reboot-cause
 and the software reboot-cause information and creates previous-reboot-cause.txt with the information.
-To log upto 10 entries of the previous reboot-cause, `process-reboot-cause` will save the previous reboot cause information
-to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp at the end of file name after processing
-the reboot-cause and create a symbolic link.
-Currently previous-reboot-cause.txt is plain text format but this file content will be formatted to be parsed easily.
+To save the history of the previous reboot-cause, `process-reboot-cause` will save the previous reboot cause information
+to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp at the end of file name.
+And the file will be formatted to be parsed easily.
 
 The example shows the previous reboot-cause files stored in /host/reboot-cause/previous-reboot-cause/.
 ```
@@ -29,11 +28,15 @@ previous-reboot-cause-20200902T015048.txt
 ```
 The following example shows the content of the previous reboot-cause file - previous-reboot-cause-20200903T232033.txt.
 ```
-TIMESTAMP: "20200903T232033"
-CAUSE: "reboot"
-USER: "admin"
-TIME: "Thu 03 Sep 2020 11:15:30 PM UTC"
-COMMENT: "User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:15:30 PM UTC]"
+[
+    {
+        gen_time: "20200903T232033",
+        cause: "reboot",
+        user: "admin",
+        time: "Thu 03 Sep 2020 11:15:30 PM UTC",
+        comment: ""
+    }
+]
 ```
 
 #### Part 2
@@ -48,7 +51,7 @@ Here is the definition of Reboot-cause schema which will be stored in state-DB.
 ; Defines information for reboot-cause
 key                     = REBOOT_CAUSE|<timestamp>         ; last reboot-cause processing time
 ; field                 = value
-cause                   = STRING                         ; last reboot cause
+cause                   = STRING                         ; last reboot causek
 time                    = STRING                         ; time when the last reboot was initiated
 user                    = STRING                         ; user who the last reboot initiated
 comment                 = STRING                         ; unstructured json format data

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -13,10 +13,9 @@
 
 #### Part 1
 During the boot, the `determine-reboot-cause` service ( previously `process-reboot-cause`) determines the last reboot-cause based on the hardware reboot-cause
-and the software reboot-cause information and creates previous-reboot-cause.txt with the information as it does currently.
-In addition, to save the history of the previous reboot-cause, `determine-reboot-cause` service will save the previous
+and the software reboot-cause information and `determine-reboot-cause` service will save the formatted last previous
 reboot cause information to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp at the end of file name.
-And the file will be formatted to be parsed easily.
+`determine-reboot-cause` also will also create a symbolic link of the last reboot cause file to "/host/reboot-cause/previous-reboot-cause.txt"
 
 The example shows the previous reboot-cause files stored in /host/reboot-cause/previous-reboot-cause/.
 ```
@@ -67,8 +66,8 @@ comment                 = STRING                         ; unstructured json for
 
 ###### reboot-cause information
 
-Currently `show reboot-cause` displays the last reboot-cause and performing `cat /host/reboot-cause/previous-reboot-cause.txt` to show the reboot-cause.
-This will be same as current design.
+`show reboot-cause` displays the last reboot-cause saved in "/host/reboot-cause/previous-reboot-cause.txt".
+This will be same as current design but the file will be symbolic-linked to the last saved file with time stamp.
 With new design, `show reboot-cause history` will be added to display the previous reboot-cause information up to 10 entries from state-DB.
 
 The example shows the output of `show reboot-cause` which is same as current output and displays only the last reboot-cause.
@@ -76,8 +75,6 @@ The example shows the output of `show reboot-cause` which is same as current out
 admin@sonic:~$ show reboot-cause
 User issued 'warm-reboot' command [User: admin, Time: Fri Oct  9 04:51:47 UTC 2020]
 ```
-
-Above output will be stored in the previous-reboot-cause.txt file.
 
 And the reboot-cause information is also stored in state-DB as follows.
 ```
@@ -105,10 +102,10 @@ name                 cause        time                          user    comment
 Above output will be stored inside state-DB as follows for the previous reboot-cause in addition to the last reboot-cause
 ```
 admin@sonic:~$ redis-cli -n 6 keys "REBOOT_CAUSE|*"
-1) "REBOOT_CAUSE|2020_10_09_02_33_06"
-2) "REBOOT_CAUSE|2020_10_09_01_56_59"
+1) "REBOOT_CAUSE|2020_10_09_04_53_58"
+2) "REBOOT_CAUSE|2020_10_09_02_33_06"
 3) "REBOOT_CAUSE|2020_10_09_02_00_53"
-4) "REBOOT_CAUSE|2020_10_09_04_53_58"
+4) "REBOOT_CAUSE|2020_10_09_01_56_59"
 
 admin@sonic:~$ redis-cli -n 6 hgetall "REBOOT_CAUSE|2020_10_09_04_53_58"
 1) "cause"

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -15,7 +15,7 @@
 During the boot, the `determine-reboot-cause` service ( previously `process-reboot-cause`) determines the last reboot-cause based on the hardware reboot-cause
 and the software reboot-cause information and `determine-reboot-cause` service will save the formatted last previous
 reboot cause information to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp at the end of file name.
-`determine-reboot-cause` also will also create a symbolic link of the last reboot cause file to "/host/reboot-cause/last-reboot-cause.json"
+`determine-reboot-cause` also will also create a symbolic link of the last reboot cause file to "/host/reboot-cause/previous-reboot-cause.json"
 
 The example shows the previous reboot-cause files stored in /host/reboot-cause/previous-reboot-cause/.
 ```
@@ -66,7 +66,7 @@ comment                 = STRING                         ; unstructured json for
 
 ###### reboot-cause information
 
-`show reboot-cause` displays the last reboot-cause saved in "/host/reboot-cause/last-reboot-cause.json".
+`show reboot-cause` displays the last reboot-cause saved in "/host/reboot-cause/previous-reboot-cause.json".
 This will be same as current design but the file will be symbolic-linked to the last saved file with time stamp.
 With new design, `show reboot-cause history` will be added to display the previous reboot-cause information up to 10 entries from state-DB.
 

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -56,7 +56,7 @@ Here is the definition of Reboot-cause schema which will be stored in state-DB.
 ; Defines information for reboot-cause
 key                     = REBOOT_CAUSE|<timestamp>         ; last reboot-cause processing time
 ; field                 = value
-cause                   = STRING                         ; last reboot causek
+cause                   = STRING                         ; last reboot cause
 time                    = STRING                         ; time when the last reboot was initiated
 user                    = STRING                         ; user who the last reboot initiated
 comment                 = STRING                         ; unstructured json format data

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -72,7 +72,7 @@ The example shows the output of `show reboot-cause` which is same as current out
 $ show reboot-cause
 User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:15:30 PM UTC]
 ```
-above output will be stored inside state-DB as follows for the reboot-cause information
+Above output will be stored inside state-DB as follows for the reboot-cause information
 ```
 REBOOT_CAUSE|20200903T112033
 "cause"  
@@ -89,11 +89,11 @@ The example shows the output of `show reboot-cause history` and the previous reb
 ```
 $ show reboot-cause history
 TIMESTAMP       REBOOT-CAUSE        Details
-20200903T232033 reboot              User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:20:33 PM UTC]
+20200903T232033 reboot              User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:15:30 PM UTC]
 20200902T101105 Unknown             Unknown
 20200902T015048 fast-reboot         User issued 'fast-reboot' command [User: admin, Time: Wed 02 Sep 2020 01:48:33 AM UTC]
 ```
-above output will be stored inside state-DB as follows for the previous reboot-cause in addition to the last reboot-cause
+Above output will be stored inside state-DB as follows for the previous reboot-cause in addition to the last reboot-cause
 ```
 REBOOT_CAUSE|20200902T101105
 "cause"  

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -15,9 +15,9 @@
 For 1st part, process-reboot-cause copies the previous-reboot-cause.txt 
 to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp 
 at the end of file name after processing the reboot-cause.
-Currently previous-reboot-cause.txt is plan text format but this file content will be formatized to be parsed easily.
+Currently previous-reboot-cause.txt is plain text format but this file content will be formatted to be parsed easily.
 Read each reboot-cause information from saved previous-reboot-cause files
-And update reboot-cause information upto 10 entries to state-DB.  
+And update reboot-cause information up to 10 entries to state-DB.  
 
 The example shows the previous reboot-cause files stored in /host/reboot-cause/previous-reboot-cause/.
 ```
@@ -28,7 +28,7 @@ previous-reboot-cause-20200902T015048.txt
 ```
 The following example shows the content of the previous reboot-cause file - previous-reboot-cause-20200903T232033.txt.
 ```
-TIMESTATEMP: "20200903T232033"
+TIMESTAMP: "20200903T232033"
 CAUSE: "reboot"
 USER: "admin"
 TIME: "Thu 03 Sep 2020 11:15:30 PM UTC"
@@ -65,7 +65,7 @@ Verify that from state-DB data is available via telemetry agent
 
 Currently `show reboot-cause` displays the last reboot-cause and performing `cat /host/reboot-cause/previous-reboot-cause.txt` to show the reboot-cause. 
 With new design, the reboot-cause will be read from state-DB and displayed with new format.
-`show reboot-cause history` will be added and displays the previous `reboot-cause` upto 10 entries from state-DB.
+`show reboot-cause history` will be added and displays the previous `reboot-cause` up to 10 entries from state-DB.
 
 The example shows the output of `show reboot-cause` which is same as current output and displays only the last reboot-cause.
 ```

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -40,8 +40,8 @@ The following example shows the content of the previous reboot-cause file - prev
 ```
 
 #### Part 2
-A new service which will retrieve the saved reboot-cause files and read each reboot-cause information from the files
-and update reboot-cause information up to 10 entries to state-DB.
+A new service named as `post-process-reboot-cause.service` which will retrieve the saved reboot-cause files and read each reboot-cause information from the files
+and save the reboot-cause information up to 10 entries to state-DB.
 Verify the information from state-DB data is available via the cli command `show reboot-cause history` which is extended from `show reboot-cause`.
 
 ##### Reboot Cause Schema in state-DB

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -15,21 +15,21 @@
 During the boot, the `determine-reboot-cause` service ( previously `process-reboot-cause`) determines the last reboot-cause based on the hardware reboot-cause
 and the software reboot-cause information and `determine-reboot-cause` service will save the formatted last previous
 reboot cause information to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp at the end of file name.
-`determine-reboot-cause` also will also create a symbolic link of the last reboot cause file to "/host/reboot-cause/previous-reboot-cause.txt"
+`determine-reboot-cause` also will also create a symbolic link of the last reboot cause file to "/host/reboot-cause/last-reboot-cause.json"
 
 The example shows the previous reboot-cause files stored in /host/reboot-cause/previous-reboot-cause/.
 ```
 admin@sonic:~$ ls /host/reboot-cause/previous-reboot-cause/
-reboot-cause-2020_10_09_01_56_59.txt
-reboot-cause-2020_10_09_02_00_53.txt
-reboot-cause-2020_10_09_02_33_06.txt
-reboot-cause-2020_10_09_04_53_58.txt
+reboot-cause-2020_10_09_01_56_59.json
+reboot-cause-2020_10_09_02_00_53.json
+reboot-cause-2020_10_09_02_33_06.json
+reboot-cause-2020_10_09_04_53_58.json
 ...
 ```
 
-The following example shows the content of the previous reboot-cause file - reboot-cause-2020_10_09_04_53_58.txt.
+The following example shows the content of the previous reboot-cause file - reboot-cause-2020_10_09_04_53_58.json.
 ```
-admin@sonic:~$ sudo cat /host/reboot-cause/previous-reboot-cause/reboot-cause-2020_10_09_04_53_58.txt
+admin@sonic:~$ sudo cat /host/reboot-cause/previous-reboot-cause/reboot-cause-2020_10_09_04_53_58.json
 {"comment": "", "gen_time": "2020_10_09_04_53_58", "cause": "warm-reboot", "user": "admin", "time": "Fri Oct  9 04:51:47 UTC 2020"}
 ```
 ```
@@ -66,7 +66,7 @@ comment                 = STRING                         ; unstructured json for
 
 ###### reboot-cause information
 
-`show reboot-cause` displays the last reboot-cause saved in "/host/reboot-cause/previous-reboot-cause.txt".
+`show reboot-cause` displays the last reboot-cause saved in "/host/reboot-cause/last-reboot-cause.json".
 This will be same as current design but the file will be symbolic-linked to the last saved file with time stamp.
 With new design, `show reboot-cause history` will be added to display the previous reboot-cause information up to 10 entries from state-DB.
 

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -7,7 +7,7 @@
 | 0.1 | 09/02/20 | Sujin Kang  | Initial version    |
 
 ## Scope
--Enable sonic streaming telemetry agent to send Reboot-cause information
+-Enable sonic streaming telemetry agent to send Reboot-cause information which is stored in state-db with the reboot-cause processed timestamp.
 
 ### Enable sonic streaming telemetry agent to send Reboot-cause information
 

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -13,9 +13,9 @@
 
 #### Part 1
 During the boot, the process-reboot-cause processes the last reboot-cause based on the hardware reboot-cause
-and the software reboot-cause information and creates previous-reboot-cause.txt with the information.
-To save the history of the previous reboot-cause, `process-reboot-cause` will save the previous reboot cause information
-to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp at the end of file name.
+and the software reboot-cause information and creates previous-reboot-cause.txt with the information as it does currently.
+In addition to save the history of the previous reboot-cause, `process-reboot-cause` will save the previous
+reboot cause information to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp at the end of file name.
 And the file will be formatted to be parsed easily.
 
 The example shows the previous reboot-cause files stored in /host/reboot-cause/previous-reboot-cause/.

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -14,12 +14,12 @@
 #### Part 1
 During the boot, the `determine-reboot-cause` service ( previously `process-reboot-cause`) determines the last reboot-cause based on the hardware reboot-cause
 and the software reboot-cause information and `determine-reboot-cause` service will save the formatted last previous
-reboot cause information to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp at the end of file name.
+reboot cause information to "/host/reboot-cause/history/" with adding timestamp at the end of file name.
 `determine-reboot-cause` also will also create a symbolic link of the last reboot cause file to "/host/reboot-cause/previous-reboot-cause.json"
 
-The example shows the previous reboot-cause files stored in /host/reboot-cause/previous-reboot-cause/.
+The example shows the previous reboot-cause files stored in /host/reboot-cause/history/.
 ```
-admin@sonic:~$ ls /host/reboot-cause/previous-reboot-cause/
+admin@sonic:~$ ls /host/reboot-cause/history/
 reboot-cause-2020_10_09_01_56_59.json
 reboot-cause-2020_10_09_02_00_53.json
 reboot-cause-2020_10_09_02_33_06.json
@@ -29,7 +29,7 @@ reboot-cause-2020_10_09_04_53_58.json
 
 The following example shows the content of the previous reboot-cause file - reboot-cause-2020_10_09_04_53_58.json.
 ```
-admin@sonic:~$ sudo cat /host/reboot-cause/previous-reboot-cause/reboot-cause-2020_10_09_04_53_58.json
+admin@sonic:~$ sudo cat /host/reboot-cause/history/reboot-cause-2020_10_09_04_53_58.json
 {"comment": "", "gen_time": "2020_10_09_04_53_58", "cause": "warm-reboot", "user": "admin", "time": "Fri Oct  9 04:51:47 UTC 2020"}
 ```
 ```

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -13,10 +13,27 @@
 
 ##### Part 1 
 For 1st part, process-reboot-cause copies the previous-reboot-cause.txt 
-to "/host/reboot-cause/previous_reboot-cause/" with adding timestamp 
+to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp 
 at the end of file name after processing the reboot-cause.
+Currently previous-reboot-cause.txt is plan text format but this file content will be formatized to be parsed easily.
 Read each reboot-cause information from saved previous-reboot-cause files
 And update reboot-cause information upto 10 entries to state-DB.  
+
+The example shows the previous reboot-cause files stored in /host/reboot-cause/previous-reboot-cause/.
+```
+$ls /host/reboot-cause/previous-reboot-cause/
+previous-reboot-cause-20200903T232033.txt
+previous-reboot-cause-20200902T101105.txt
+previous-reboot-cause-20200902T015048.txt
+```
+The following example shows the content of the previous reboot-cause file - previous-reboot-cause-20200903T232033.txt.
+```
+TIMESTATEMP: "20200903T232033"
+CAUSE: "reboot"
+USER: "admin"
+TIME: "Thu 03 Sep 2020 11:15:30 PM UTC"
+COMMENT: "User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:15:30 PM UTC]" 
+```
 
 Details of CLI and state-DB given below. 
 Cli command to retrieve the Reboot-cause information
@@ -46,31 +63,39 @@ Verify that from state-DB data is available via telemetry agent
 
 ###### reboot-cause information
 
-Software User `reboot` cause example :
+Currently `show reboot-cause` displays the last reboot-cause and performing `cat /host/reboot-cause/previous-reboot-cause.txt` to show the reboot-cause. 
+With new design, the reboot-cause will be read from state-DB and displayed with new format.
+`show reboot-cause history` will be added and displays the previous `reboot-cause` upto 10 entries from state-DB.
+
+The example shows the output of `show reboot-cause` which is same as current output and displays only the last reboot-cause.
 ```
 $ show reboot-cause
-User issued 'reboot' command [User: admin, Time: Wed 02 Sep 2020 05:48:42 PM UTC]
+User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:15:30 PM UTC]
 ```
 above output will be stored inside state-DB as follows for the reboot-cause information
 ```
-REBOOT_CAUSE|4276  
+REBOOT_CAUSE|20200903T112033
 "cause"  
 "reboot"  
 "time"  
-"Wed 02 Sep 2020 05:48:42 PM UTC"  
+"Thu 03 Sep 2020 11:15:30 PM UTC"  
 "user"  
 "admin"  
 "comment"  
-"User issued 'reboot' command [User: admin, Time: Wed 02 Sep 2020 05:48:42 PM UTC]"  
+"User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:15:30 PM UTC]"  
 ```
-Hardware `Unknown` cause example : 
+
+The example shows the output of `show reboot-cause history` and the previous reboot cause stored in state-DB in addition to the last reboot-cause.
 ```
-$ show reboot-cause
-User issued 'reboot' command [User: admin, Time: Wed 02 Sep 2020 05:48:42 PM UTC]
+$ show reboot-cause history
+TIMESTAMP       REBOOT-CAUSE        Details
+20200903T232033 reboot              User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:20:33 PM UTC]
+20200902T101105 Unknown             Unknown
+20200902T015048 fast-reboot         User issued 'fast-reboot' command [User: admin, Time: Wed 02 Sep 2020 01:48:33 AM UTC]
 ```
-above output will be stored inside state-DB as follows for the reboot-cause information
+above output will be stored inside state-DB as follows for the previous reboot-cause in addition to the last reboot-cause
 ```
-REBOOT_CAUSE|4170  
+REBOOT_CAUSE|20200902T101105
 "cause"  
 "Unknown"  
 "time"  
@@ -79,4 +104,15 @@ REBOOT_CAUSE|4170
 ""
 "comment"  
 "Unknown"
+```
+```
+REBOOT_CAUSE|20200902T015048
+"cause"  
+"fast-reboot"  
+"time"  
+"Wed 02 Sep 2020 01:48:33 AM UTC"  
+"user"  
+"admin"  
+"comment"  
+"User issued 'fast-reboot' command [User: admin, Time: Wed 02 Sep 2020 01:48:33 AM UTC]"  
 ```

--- a/doc/system-telemetry/reboot-cause.md
+++ b/doc/system-telemetry/reboot-cause.md
@@ -11,13 +11,13 @@
 
 ### Enable sonic streaming telemetry agent to send Reboot-cause information
 
-##### Part 1 
-For 1st part, process-reboot-cause copies the previous-reboot-cause.txt 
-to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp 
-at the end of file name after processing the reboot-cause.
+#### Part 1
+During the boot, the process-reboot-cause processes the last reboot-cause based on the hardware reboot-cause
+and the software reboot-cause information and creates previous-reboot-cause.txt with the information.
+To log upto 10 entries of the previous reboot-cause, `process-reboot-cause` will save the previous reboot cause information
+to "/host/reboot-cause/previous-reboot-cause/" with adding timestamp at the end of file name after processing
+the reboot-cause and create a symbolic link.
 Currently previous-reboot-cause.txt is plain text format but this file content will be formatted to be parsed easily.
-Read each reboot-cause information from saved previous-reboot-cause files
-And update reboot-cause information up to 10 entries to state-DB.  
 
 The example shows the previous reboot-cause files stored in /host/reboot-cause/previous-reboot-cause/.
 ```
@@ -25,6 +25,7 @@ $ls /host/reboot-cause/previous-reboot-cause/
 previous-reboot-cause-20200903T232033.txt
 previous-reboot-cause-20200902T101105.txt
 previous-reboot-cause-20200902T015048.txt
+...
 ```
 The following example shows the content of the previous reboot-cause file - previous-reboot-cause-20200903T232033.txt.
 ```
@@ -32,57 +33,51 @@ TIMESTAMP: "20200903T232033"
 CAUSE: "reboot"
 USER: "admin"
 TIME: "Thu 03 Sep 2020 11:15:30 PM UTC"
-COMMENT: "User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:15:30 PM UTC]" 
+COMMENT: "User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:15:30 PM UTC]"
 ```
 
-Details of CLI and state-DB given below. 
-Cli command to retrieve the Reboot-cause information
-```
-$ show reboot-cause
-```
-state-DB schema to store the Reboot-cause information
+#### Part 2
+A new service which will retrieve the saved reboot-cause files and read each reboot-cause information from the files
+and update reboot-cause information up to 10 entries to state-DB.
+Verify the information from state-DB data is available via the cli command `show reboot-cause history` which is extended from `show reboot-cause`.
+
+##### Reboot Cause Schema in state-DB
+
+Here is the definition of Reboot-cause schema which will be stored in state-DB.
 ```
 ; Defines information for reboot-cause
-key                     = REBOOT_CAUSE|timestamp         ; last reboot-cause processing time
+key                     = REBOOT_CAUSE|<timestamp>         ; last reboot-cause processing time
 ; field                 = value
 cause                   = STRING                         ; last reboot cause
 time                    = STRING                         ; time when the last reboot was initiated
 user                    = STRING                         ; user who the last reboot initiated
 comment                 = STRING                         ; unstructured json format data
 ```
-Along with data new entry for timestamp will be added up to 10 entries in state_db:  
-
-```
-REBOOT_CAUSE|timestamp
-```
-
-##### Part 2
-Verify that from state-DB data is available via telemetry agent
 
 ##### CLI output  and corresponding structure in state-DB for reboot-cause information
 
 ###### reboot-cause information
 
-Currently `show reboot-cause` displays the last reboot-cause and performing `cat /host/reboot-cause/previous-reboot-cause.txt` to show the reboot-cause. 
-With new design, the reboot-cause will be read from state-DB and displayed with new format.
-`show reboot-cause history` will be added and displays the previous `reboot-cause` up to 10 entries from state-DB.
+Currently `show reboot-cause` displays the last reboot-cause and performing `cat /host/reboot-cause/previous-reboot-cause.txt` to show the reboot-cause.
+This will be same as current design.
+With new design, `show reboot-cause history` will be added to display the previous `reboot-cause` up to 10 entries from state-DB.
 
 The example shows the output of `show reboot-cause` which is same as current output and displays only the last reboot-cause.
 ```
 $ show reboot-cause
 User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:15:30 PM UTC]
 ```
-Above output will be stored inside state-DB as follows for the reboot-cause information
+Above output will be stored in the previous-reboot-cause.txt file and the reboot-cause information is also stored in state-DB as follows.
 ```
 REBOOT_CAUSE|20200903T112033
-"cause"  
-"reboot"  
-"time"  
-"Thu 03 Sep 2020 11:15:30 PM UTC"  
-"user"  
-"admin"  
-"comment"  
-"User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:15:30 PM UTC]"  
+"cause"
+"reboot"
+"time"
+"Thu 03 Sep 2020 11:15:30 PM UTC"
+"user"
+"admin"
+"comment"
+"User issued 'reboot' command [User: admin, Time: Thu 03 Sep 2020 11:15:30 PM UTC]"
 ```
 
 The example shows the output of `show reboot-cause history` and the previous reboot cause stored in state-DB in addition to the last reboot-cause.
@@ -96,23 +91,23 @@ TIMESTAMP       REBOOT-CAUSE        Details
 Above output will be stored inside state-DB as follows for the previous reboot-cause in addition to the last reboot-cause
 ```
 REBOOT_CAUSE|20200902T101105
-"cause"  
-"Unknown"  
-"time"  
+"cause"
+"Unknown"
+"time"
 ""
-"user"  
+"user"
 ""
-"comment"  
+"comment"
 "Unknown"
 ```
 ```
 REBOOT_CAUSE|20200902T015048
-"cause"  
-"fast-reboot"  
-"time"  
-"Wed 02 Sep 2020 01:48:33 AM UTC"  
-"user"  
-"admin"  
-"comment"  
-"User issued 'fast-reboot' command [User: admin, Time: Wed 02 Sep 2020 01:48:33 AM UTC]"  
+"cause"
+"fast-reboot"
+"time"
+"Wed 02 Sep 2020 01:48:33 AM UTC"
+"user"
+"admin"
+"comment"
+"User issued 'fast-reboot' command [User: admin, Time: Wed 02 Sep 2020 01:48:33 AM UTC]"
 ```


### PR DESCRIPTION
To support the reboot-cause information sending via telemetry agent, this HLD proposes the state-DB schema and how to process the reboot-cause information during the reboot-cause-process.