### PR TITLE
Added SNMP_USER_PERMISSIONS parameter and removed SNMP_USER_STRING parameter

### DIFF
--- a/doc/snmp/snmp-schema-addition.md
+++ b/doc/snmp/snmp-schema-addition.md
@@ -66,7 +66,8 @@ In the end this is used to produce */etc/snmp/snmpd.conf*.
          "SNMP_USER_AUTH_TYPE":"MD5|SHA|HMAC-SHA-2",
          "SNMP_USER_ENCRYPTION_TYPE":"DES|AES",
          "SNMP_USER_AUTH_PASSWORD":"<AUTH_PASSWORD_STRING>",
-         "SNMP_USER_ENCRYPTION_PASSWORD":"<ENCRYPTION_PASSWORD_STRING>"
+         "SNMP_USER_ENCRYPTION_PASSWORD":"<ENCRYPTION_PASSWORD_STRING>",
+         "SNMP_USER_PERMISSIONS": "RO|RW"
       },
       "<SNMP_USER>":{
          "SNMP_USER_STRING":"<SNMP_USER_STRING>",
@@ -74,7 +75,8 @@ In the end this is used to produce */etc/snmp/snmpd.conf*.
          "SNMP_USER_AUTH_TYPE":"MD5|SHA|HMAC-SHA-2",
          "SNMP_USER_ENCRYPTION_TYPE":"DES|AES",
          "SNMP_USER_AUTH_PASSWORD":"<AUTH_PASSWORD_STRING>",
-         "SNMP_USER_ENCRYPTION_PASSWORD":"<ENCRYPTION_PASSWORD_STRING>"
+         "SNMP_USER_ENCRYPTION_PASSWORD":"<ENCRYPTION_PASSWORD_STRING>",
+         "SNMP_USER_PERMISSIONS": "RO|RW"
       },
       "<SNMP_USER>":{
          "SNMP_USER_STRING":"<SNMP_USER_STRING>",
@@ -82,7 +84,8 @@ In the end this is used to produce */etc/snmp/snmpd.conf*.
          "SNMP_USER_AUTH_TYPE":"MD5|SHA|HMAC-SHA-2",
          "SNMP_USER_ENCRYPTION_TYPE":"DES|AES",
          "SNMP_USER_AUTH_PASSWORD":"<AUTH_PASSWORD_STRING>",
-         "SNMP_USER_ENCRYPTION_PASSWORD":"<ENCRYPTION_PASSWORD_STRING>"
+         "SNMP_USER_ENCRYPTION_PASSWORD":"<ENCRYPTION_PASSWORD_STRING>",
+         "SNMP_USER_PERMISSIONS": "RO|RW"
       }
    }
 }
@@ -99,7 +102,7 @@ Where:
 - SNMP_USER_ENCRYPTION_TYPE: String, defines which encryption type will be used for that SNMP user DES or AES. 
 - SNMP_USER_AUTH_PASSWORD: String, defines which authentication password will be used for that SNMP user.
 - SNMP_USER_ENCRYPTION_PASSWORD: String, defines which encryption password will be used for that SNMP user. 
-
+- SNMP_USER_PERMISSIONS: String, RO (Read-Only) or RW (Read-Write) defines what will be used for that SNMP user.
 
 
 New keys:

--- a/doc/snmp/snmp-schema-addition.md
+++ b/doc/snmp/snmp-schema-addition.md
@@ -66,7 +66,7 @@ In the end this is used to produce */etc/snmp/snmpd.conf*.
          "SNMP_USER_ENCRYPTION_TYPE":"DES|AES",
          "SNMP_USER_AUTH_PASSWORD":"<AUTH_PASSWORD_STRING>",
          "SNMP_USER_ENCRYPTION_PASSWORD":"<ENCRYPTION_PASSWORD_STRING>",
-         "SNMP_USER_PERMISSIONS": "RO|RW"
+         "SNMP_USER_PERMISSION": "RO|RW"
       },
       "<SNMP_USER>":{
          "SNMP_USER_TYPE":"noAuthNoPriv|AuthNoPriv|Priv",
@@ -74,7 +74,7 @@ In the end this is used to produce */etc/snmp/snmpd.conf*.
          "SNMP_USER_ENCRYPTION_TYPE":"DES|AES",
          "SNMP_USER_AUTH_PASSWORD":"<AUTH_PASSWORD_STRING>",
          "SNMP_USER_ENCRYPTION_PASSWORD":"<ENCRYPTION_PASSWORD_STRING>",
-         "SNMP_USER_PERMISSIONS": "RO|RW"
+         "SNMP_USER_PERMISSION": "RO|RW"
       },
       "<SNMP_USER>":{
          "SNMP_USER_TYPE":"noAuthNoPriv|AuthNoPriv|Priv",
@@ -82,7 +82,7 @@ In the end this is used to produce */etc/snmp/snmpd.conf*.
          "SNMP_USER_ENCRYPTION_TYPE":"DES|AES",
          "SNMP_USER_AUTH_PASSWORD":"<AUTH_PASSWORD_STRING>",
          "SNMP_USER_ENCRYPTION_PASSWORD":"<ENCRYPTION_PASSWORD_STRING>",
-         "SNMP_USER_PERMISSIONS": "RO|RW"
+         "SNMP_USER_PERMISSION": "RO|RW"
       }
    }
 }
@@ -99,7 +99,7 @@ Where:
 - SNMP_USER_ENCRYPTION_TYPE: String, defines which encryption type will be used for that SNMP user DES or AES. 
 - SNMP_USER_AUTH_PASSWORD: String, defines which authentication password will be used for that SNMP user.
 - SNMP_USER_ENCRYPTION_PASSWORD: String, defines which encryption password will be used for that SNMP user. 
-- SNMP_USER_PERMISSIONS: String, RO (Read-Only) or RW (Read-Write) defines what will be used for that SNMP user.
+- SNMP_USER_PERMISSION: String, RO (Read-Only) or RW (Read-Write) defines what will be used for that SNMP user.
 
 
 New keys:

--- a/doc/snmp/snmp-schema-addition.md
+++ b/doc/snmp/snmp-schema-addition.md
@@ -61,7 +61,6 @@ In the end this is used to produce */etc/snmp/snmpd.conf*.
 {
    "SNMP_USER":{
       "<SNMP_USER>":{
-         "SNMP_USER_STRING":"<SNMP_USER_STRING>",
          "SNMP_USER_TYPE":"noAuthNoPriv|AuthNoPriv|Priv",
          "SNMP_USER_AUTH_TYPE":"MD5|SHA|HMAC-SHA-2",
          "SNMP_USER_ENCRYPTION_TYPE":"DES|AES",
@@ -70,7 +69,6 @@ In the end this is used to produce */etc/snmp/snmpd.conf*.
          "SNMP_USER_PERMISSIONS": "RO|RW"
       },
       "<SNMP_USER>":{
-         "SNMP_USER_STRING":"<SNMP_USER_STRING>",
          "SNMP_USER_TYPE":"noAuthNoPriv|AuthNoPriv|Priv",
          "SNMP_USER_AUTH_TYPE":"MD5|SHA|HMAC-SHA-2",
          "SNMP_USER_ENCRYPTION_TYPE":"DES|AES",
@@ -79,7 +77,6 @@ In the end this is used to produce */etc/snmp/snmpd.conf*.
          "SNMP_USER_PERMISSIONS": "RO|RW"
       },
       "<SNMP_USER>":{
-         "SNMP_USER_STRING":"<SNMP_USER_STRING>",
          "SNMP_USER_TYPE":"noAuthNoPriv|AuthNoPriv|Priv",
          "SNMP_USER_AUTH_TYPE":"MD5|SHA|HMAC-SHA-2",
          "SNMP_USER_ENCRYPTION_TYPE":"DES|AES",


### PR DESCRIPTION
Added one new parameters: 
"SNMP_USER_PERMISSIONS": "RO|RW" to SNMP_USERS. 
This will be needed to support RW SNMPv3 in the future. 


Removed "SNMP_USER_STRING".   This is not necessary because we have this 
SNMP_USER|user1 which shows the user string as "user1" as a key. 