### PR TITLE
updated SNMP|CONTACT|CONTACT to SNMP|CONTACT|<CONTACT_NAME>

### DIFF
--- a/doc/snmp/snmp-schema-addition.md
+++ b/doc/snmp/snmp-schema-addition.md
@@ -33,7 +33,7 @@ In the end this is used to produce */etc/snmp/snmpd.conf*.
          "LOCATION":"<SNMP_LOCATION_STRING>"
       },
       "CONTACT":{
-         "CONTACT":"<SNMP_CONTACT_STRING>"
+         "<CONTACT_NAME>":"<SNMP_CONTACT_STRING>"
       }
    }
 }


### PR DESCRIPTION
Updated Schema for contact: 
```
admin@str-s6000-acs-11:~$ redis-cli -n 4 hgetall "SNMP|CONTACT"
1) "travis"
2) "travis@contoso.com"
```
Instead of SNMP|CONTACT|CONTACT|<contact-email>.  Fixed this to be correct.