### PR TITLE
Port auto negotiation high level design document

### DIFF
--- a/doc/port_auto_neg/port-auto-negotiation-design.md
+++ b/doc/port_auto_neg/port-auto-negotiation-design.md
@@ -16,7 +16,7 @@ N/A
  
 ### Overview
 
-The IEEE 802.3 standard defines a set of Ethernet protocols that are comprised of speed rate and interface type. It allows for configuring multiple values at the same time for port provisioning and advertising to the remote side. However, on SONiC, user can configure the speed of port, and user can configure auto negotiation mode via config DB. Auto negotiation attributes such as interface type, advertised speeds, advertised interface types are not supported.
+The IEEE 802.3 standard defines a set of Ethernet protocols that are comprised of speed rate and interface type. It allows for configuring multiple values at the same time for port provisioning and advertising to the remote side. However, on SONiC, user can configure the speed of port, and user can configure auto negotiation mode via config DB. Port attributes such as interface type, advertised speeds, advertised interface types are not supported.
 
 The feature in this document is to address the above issues.
 

--- a/doc/port_auto_neg/port-auto-negotiation-design.md
+++ b/doc/port_auto_neg/port-auto-negotiation-design.md
@@ -207,19 +207,11 @@ Example:
 Return:
   error message if interface_name is invalid otherwise:
 
-  Ethernet0:
-      Auto-Neg Mode: Enabled
-      Speed: 100G
-      Advertised Speeds: 10G,25G,40G,100G
-      Interface Type: CR4
-      Advertised Interface Types: CR4,KR4
-  Ethernet4:
-      Auto-Neg Mode: N/A
-      Speed: 100G
-      Advertised Speeds: N/A
-      Interface Type: N/A
-      Advertised Interface Types: N/A
-  ...
+  Name         Auto-Neg Mode    Speed    Advertised Speeds    Interface Type    Advertised Interface Types
+  -----------  ---------------  -------  -------------------  ----------------  ----------------------------
+  Ethernet0    disabled         40G      N/A                  N/A               N/A
+  Ethernet4    enabled          40G      40G,100G             CR4               CR4,SR4
+
 ```
 
 #### Config DB Enhancements  

--- a/doc/port_auto_neg/port-auto-negotiation-design.md
+++ b/doc/port_auto_neg/port-auto-negotiation-design.md
@@ -238,14 +238,14 @@ As command `show interfaces status` already has 11 columns, a new CLI command wi
 
 ```
 Format:
-  show interfaces status autoneg <interface_name>
+  show interfaces autoneg-status <interface_name>
 
 Arguments:
   interface_name: optional. Name of the interface to be shown. e.g: Ethernet0. If interface_name is not given, this command shows auto negotiation status for all interfaces.
 
 Example:
-  show interfaces status autoneg
-  show interfaces status autoneg Ethernet0
+  show interfaces autoneg-status
+  show interfaces autoneg-status Ethernet0
 
 Return:
   error message if interface_name is invalid otherwise:

--- a/doc/port_auto_neg/port-auto-negotiation-design.md
+++ b/doc/port_auto_neg/port-auto-negotiation-design.md
@@ -1,0 +1,305 @@
+# SONiC Port Auto Negotiation Design #
+
+## Table of Content 
+
+### Revision ###
+
+ | Rev |     Date    |       Author       | Change Description                |
+ |:---:|:-----------:|:------------------:|-----------------------------------|
+ | 0.1 |             |      Junchao Chen  | Initial version                   |
+
+### Scope
+This document is the design document for port auto negotiation feature on SONiC. This includes the requirements, yang model change, CLI change, DB schema change and swss change.
+
+### Definitions/Abbreviations 
+N/A
+ 
+### Overview
+
+The IEEE 802.3 standard defines a set of Ethernet protocols that are comprised of speed rate and interface type. It allows for configuring multiple values at the same time for port provisioning and advertising to the remote side. However, on SONiC, user can configure the speed of port, and user can configure auto negotiation mode via config DB. Auto negotiation attributes such as interface type, advertised speeds, advertised interface types are not supported.
+
+The feature in this document is to address the above issues.
+
+### Requirements
+
+The main goal of this document is to discuss the design of following requirement:
+
+- Allow user to configure auto negotiation via CLI
+- Allow user to configure advertised speeds
+- Allow user to configure interface type
+- Allow user to configure advertised interface types
+
+### Architecture Design
+
+This feature does not change the existing SONiC architecture. 
+
+This feature introduces a few new CLI commands which will fit in sonic-utilities. And this feature also requires to change the configuration flow for port auto negotiation attributes which will be covered in orchagent.
+
+### High-Level Design
+
+- 4 new CLI commands will be added to sonic-utilities sub module. These CLI commands support user to configure auto negotiation mode, advertised speeds, interface type and advertised interface types for a given interface. See detail description in section [CLI Enhancements](#cli-enhancements).
+- Port speed setting flow will be changed in orchagent of sonic-swss. See detail description in section [SWSS Enhancements](#swss-enhancements).
+- A few new fields will be added to existing table in APP_DB and CONFIG_DB to support auto negotiation attributes. See detail description in section [Config DB Enhancements](#config-db-enhancements) and [Application DB Enhancements](#application-db-enhancements).
+- SAI API requirements is covered in section [SAI API](#sai-api).
+
+### SAI API
+
+Currently, SAI already defines a few port attributes to support port auto negotiation. SAI API must return error if any of the given attributes is not supported. Please note that `SAI_PORT_ATTR_ADVERTISED_INTERFACE_TYPE` is a new attribute introduced in SAI 1.7.1. As SAI 1.7.1 is not merged to master branch at this time, vendors need to implement this attribute in their SAI implementation. Vendor specified SAI implementation is not in the scope of this document. The related port attributes are listed below:
+```cpp
+    /**
+     * @brief Query/Configure Port's Advertised auto-negotiation configuration
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_PORT_ATTR_ADVERTISED_AUTO_NEG_MODE,
+    /**
+     * @brief Speed in Mbps
+     *
+     * On get, returns the configured port speed.
+     *
+     * @type sai_uint32_t
+     * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
+     */
+    SAI_PORT_ATTR_SPEED,
+    /**
+     * @brief Query/Configure list of Advertised port speed (Full-Duplex) in Mbps
+     *
+     * Used when auto negotiation is on. Empty list means all supported values are enabled.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_PORT_ATTR_ADVERTISED_SPEED,
+    /**
+     * @brief Configure Interface type
+     *
+     * @type sai_port_interface_type_t
+     * @flags CREATE_AND_SET
+     * @default SAI_PORT_INTERFACE_TYPE_NONE
+     */
+    SAI_PORT_ATTR_INTERFACE_TYPE,
+
+    /**
+     * @brief Configure advertised interface type list
+     *
+     * Used when auto negotiation is on. Empty list means all supported values are enabled.
+     *
+     * @type sai_s32_list_t sai_port_interface_type_t
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_PORT_ATTR_ADVERTISED_INTERFACE_TYPE,
+```
+
+### Configuration and management 
+
+#### CLI Enhancements 
+
+A few new CLI commands are designed to support port auto negotiation.
+
+##### Config auto negotiation mode
+
+```
+Format:
+  config interface autoneg <interface_name> <mode>
+
+Arguments:
+  interface_name: name of the interface to be configured. e.g: Ethernet0
+  mode: auto negotiation mode, can be either "enabled" or "disabled"
+
+Example:
+  config interface autoneg Ethernet0 enabled
+  config interface autoneg Ethernet0 disabled
+
+Return:
+  error message if interface_name or mode is invalid otherwise empty
+```
+
+##### Config advertised speeds
+
+This command works only if auto negotiation is enabled.
+
+```
+Format:
+  config interface advertised_speeds <interface_name> <speed_list>
+
+Arguments:
+  interface_name: name of the interface to be configured. e.g: Ethernet0
+  speed_list: a list of speeds to be advertised or "all". e.g: 40000,100000.
+
+Example:
+  config interface advertised_speeds Ethernet0 40000,100000
+  config interface advertised_speeds Ethernet0 all
+
+Return:
+  error message if interface_name or speed_list is invalid otherwise empty
+
+Note:
+  speed_list value "all" means all supported speeds 
+```
+
+##### Config interface type
+
+This command works only if auto negotiation is disabled.
+
+```
+Format:
+  config interface interface_type <interface_name> <interface_type>
+
+Arguments:
+  interface_name: name of the interface to be configured. e.g: Ethernet0
+  interface_type: interface type, valid value include: KR4, SR4 and so on. A list of valid interface type could be found at saiport.h.
+
+Example:
+  config interface interface_type Ethernet0 KR4
+
+Return:
+  error message if interface_name or interface_type is invalid otherwise empty
+```
+
+##### Config advertised interface types
+
+This command works only if auto negotiation is enabled.
+
+```
+Format:
+  config interface advertised_interface_types <interface_name> <interface_type_list>
+
+Arguments:
+  interface_name: name of the interface to be configured. e.g: Ethernet0
+  media_type_list: a list of interface types to be advertised or "all". e.g: KR4,SR4.
+
+Example:
+  config interface advertised_interface_types Ethernet0 KR4,SR4
+  config interface advertised_interface_types all
+
+Return:
+  error message if interface_name or interface_type_list is invalid otherwise empty
+
+Note:
+  media_type_list value "all" means all supported interface type 
+```
+
+#### Config DB Enhancements  
+
+SONiC already defined two fields related to port speed setting: **speed**, **autoneg**. 3 new fields **adv_speeds**, **interface_type**, **adv_interface_types** will be added to **PORT** table:
+
+	; Defines information for port configuration
+	key                     = PORT|port_name                 ; configuration of the port
+	; field                 = value
+    ...
+	adv_speeds              = STRING                         ; advertised speed list
+	interface_type          = STRING                         ; interface type
+	adv_interface_types     = STRING                         ; advertised interface types
+
+Valid value of the new fields are described below:
+
+- adv_speeds: string value "all" or a list of speed value separated by commas. For example: "50000,100000", "all".
+- interface_type: valid interface type value defined in IEEE 802.3. For example: "CR4", "SR4" and so on.
+- adv_interface_types: string value "all" or a list of interface type values defined in IEEE 802.3. For example: "CR4,KR4,SR4", "all".
+
+#### Application DB Enhancements
+
+The change in APP_DB is similar to CONFIG_DB. 3 new fields **adv_speeds**, **interface_type**, **adv_interface_types** will be added to **PORT_TABLE** table:
+
+	; Defines information for port configuration
+	key                     = PORT_TABLE:port_name           ; configuration of the port
+	; field                 = value
+    ...
+	adv_speeds              = STRING                         ; advertised speed list
+	interface_type          = STRING                         ; interface type
+	adv_interface_types     = STRING                         ; advertised interface types
+
+Valid value of the new fields are the same as **PORT** table in CONFIG_DB.
+
+Here is the table to map the fields and SAI attributes:
+| **Parameter**       | **sai_port_attr_t**
+|---------------------|------------------------------------------------|
+| adv_interface_types | SAI_PORT_ATTR_ADVERTISED_INTERFACE_TYPE        |
+| adv_speeds          | SAI_PORT_ATTR_ADVERTISED_SPEED                 |
+| autoneg             | SAI_PORT_ATTR_AUTO_NEG_MODE                    |
+| interface_type      | SAI_PORT_ATTR_INTERFACE_TYPE                   |
+| speed               | SAI_PORT_ATTR_SPEED                            |
+
+#### SWSS Enhancements
+
+The current SONiC speed setting flow in PortsOrch can be described in following pseudo code:
+
+```
+port = getPort(alias)
+if autoneg changed:
+    setPortAutoNeg(port, autoneg)
+
+if autoneg == true and speed is set:
+    setPortAdvSpeed(port, speed)
+else if autoneg == false and speed is set:
+    setPortSpeed(port, speed)
+```
+
+The new SONiC speed setting flow can be described in following pseudo code:
+
+```
+port = getPort(alias)
+if autoneg changed:
+    setPortAutoNeg(port, autoneg)
+
+if autoneg == true:
+    speed_list = vector()
+    if adv_speeds is set:
+        speed_list = adv_speeds
+    else if speed is set: // for backward compatible
+        speed_list.push_back(speed)
+    else:
+        speed_list = all_supported_speeds
+    setPortAdvSpeed(port, speed_list)
+
+    interface_type_list = vector()
+    if adv_interface_types is set:
+        interface_type_list = adv_interface_types
+    else:
+        interface_type_list = all_supported_interface_types
+    setPortAdvInterfaceType(port, interface_type_list)
+else:
+    if speed is set:
+        setPortSpeed(port, speed)
+    if interface_type is set:
+        setInterfaceType(port, interface_type)
+```
+
+### Warmboot and Fastboot Design Impact
+
+N/A
+
+### Restrictions/Limitations
+
+N/A
+
+### Testing Requirements/Design
+
+#### Unit Test cases
+
+For sonic-utilities, we will leverage the existing unit test framework to test. A few new test cases will be added:
+
+1. Test command `config interface autoneg <interface_name> <mode>`. Verify the command return error if given invalid interface_name or mode.
+2. Test command `config interface advertised_speeds <interface_name> <speed_list>`. Verify the command return error if given invalid interface name or speed list.
+3. Test command `config interface interface_type <interface_name> <interface_type>`. Verify the command return error if given invalid interface name or interface type.
+4. Test command `config interface advertised_interface_types <interface_name> <interface_type_list>`. Verify the command return error if given invalid interface name or interface type list.
+
+For sonic-swss, there is an existing test case [test_port_an](https://github.com/Azure/sonic-swss/blob/master/tests/test_port_an.py). The existing test case covers autoneg and speed attributes on both direct and warm-reboot scenario. So new unit test cases need cover the newly supported attributes:
+
+1. Test attribute adv_speeds on both direct and warm-reboot scenario. Verify SAI_PORT_ATTR_ADVERTISED_SPEED is in ASIC_DB and has correct value.
+2. Test attribute interface_type on both direct and warm-reboot scenario. Verify SAI_PORT_ATTR_INTERFACE_TYPE is in ASIC_DB and has correct value.
+3. Test attribute adv_interface_types on both direct and warm-reboot scenario. Verify SAI_PORT_ATTR_ADVERTISED_INTERFACE_TYPE is in ASIC_DB and has correct value.
+
+#### System Test cases
+
+Will leverage sonic-mgmt to test this feature.
+
+TBD
+
+### Open/Action items - if any
+
+- CLI commands cannot validate the supported speeds and supported interface types for now

--- a/doc/port_auto_neg/port-auto-negotiation-design.md
+++ b/doc/port_auto_neg/port-auto-negotiation-design.md
@@ -40,7 +40,6 @@ This feature introduces a few new CLI commands which will fit in sonic-utilities
 - SAI API requirements is covered in section [SAI API Requirement](#sai-api-requirement).
 - 5 new CLI commands will be added to sonic-utilities sub module. These CLI commands support user to configure auto negotiation mode, advertised speeds, interface type， advertised interface types for a given interface as well as show port auto negotiation configuration. See detail description in section [CLI Enhancements](#cli-enhancements).
 - A few new fields will be added to existing table in APP_DB and CONFIG_DB to support auto negotiation attributes. See detail description in section [Config DB Enhancements](#config-db-enhancements) and [Application DB Enhancements](#application-db-enhancements).
-- DB migrator need handle the existing autoneg configuration and migrate to the new configuration. See detail description in section [DB Migrator Enhancements](#db-migrator-enhancements)
 - Port speed setting flow will be changed in orchagent of sonic-swss. See detail description in section [SWSS Enhancements](#swss-enhancements).
 ### SAI API Requirement
 
@@ -257,29 +256,6 @@ Here is the table to map the fields and SAI attributes:
 | interface_type      | SAI_PORT_ATTR_INTERFACE_TYPE                   |
 | speed               | SAI_PORT_ATTR_SPEED                            |
 
-#### DB Migrator Enhancements
-
-In current SONiC implementation, if auto negotiation is enabled, it uses the `speed` field as the advertised speeds. Since this feature introduced a new field `adv_speeds`, we need do DB migration to keep backward compatible. For example, the configuration: 
-
-```json
-"Ethernet0": {
-    ...
-    "autoneg": "1",
-    "speed": "100000"
-}
-```
-
-Will be migrated to:
-
-```json
-"Ethernet0": {
-    ...
-    "autoneg": "1",
-    "speed": "100000",
-    "adv_speeds": "100000"
-}
-```
-
 #### SWSS Enhancements
 
 The current SONiC speed setting flow in PortsOrch can be described in following pseudo code:
@@ -307,6 +283,8 @@ if autoneg == true:
     if adv_speeds is set && adv_speeds != "all":
         // if adv_speeds == "all", leave speed_list empty which means all supported speeds
         speed_list = adv_speeds
+    else if speed is set:
+        speed_list.push_back(speed)  // for backward compatible
     setPortAdvSpeed(port, speed_list)
 
     interface_type_list = vector()


### PR DESCRIPTION
Why I did this?

The IEEE 802.3 standard defines a set of Ethernet protocols that are comprised of speed rate and interface type. It allows for configuring multiple values at the same time for port provisioning and advertising to the remote side. However, on SONiC, user can configure the speed of port, and user can configure auto negotiation mode via config DB. Port attributes such as interface type, advertised speeds, advertised interface types are not supported.

The feature in this document is to address the above issues.

Related PRs:
| PR title | state | context |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| [[YANG] Enhance the port yang model with new port fields: adv_speeds, interface_type and adv_interface_types](https://github.com/Azure/sonic-buildimage/pull/6948) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-buildimage/6948) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-buildimage/6948) |
| [[sonic-swss] Add port auto negotiation support to swss](https://github.com/Azure/sonic-swss/pull/1714) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-swss/1714) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-swss/1714) |
| [Add test cases for port auto negotiation feature](https://github.com/Azure/sonic-mgmt/pull/3376) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-mgmt/3376) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-mgmt/3376) |
| [[sonic-utilities] CLI support for port auto negotiation](https://github.com/Azure/sonic-utilities/pull/1568) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-utilities/1568) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-utilities/1568) |