### PR TITLE
Design document for Y-cable API support for multiple vendors

### DIFF
--- a/doc/y_cable/design_doc.md
+++ b/doc/y_cable/design_doc.md
@@ -1,5 +1,13 @@
 ## Multiple y cable vendor API design
 
+## Revision
+
+| Rev | Date     | Author          | Change Description |
+|:---:|:--------:|:---------------:|--------------------|
+| 0.1 | 03/22/21 | Vaibhav Dahiya  | Initial version    |
+
+## Scope
+
 ### Overview
 
 This document summarizes the approach taken to accommodate multiple
@@ -12,81 +20,87 @@ and all the feature requirements are met.
 Challenge: to provide an interface for Y cable to interact with PMON docker and HOST
            which can be uniform across all vendors.
 
+
+### Vendor to Module mapping
+
+#### Background
+
+- We need to have a vendor to Y cable module mappings defined and accessible somewhere for PMon container/cli to import
+
+  - Before calling any Y cable API, how do we know which type/vendor does the Y cable belong to ?
+  - Also lets suppose once the type/vendor of the cable is known from where does PMon container or cli import the module ?
+  - Since there can be many specs which vendors follow (8636, 8624 etc.) for transceivers it is important to have a solution which meets all requirements so that the API access is available to whoever wants to invoke it.
+  - another issue is how do we support the multiple vendors modules/packages which could be used by both SONiC PMon container docker as well as the sonic cli (sonic-utilities). Basically the package should be available both in host and container.
+#### Proposed Solution
+
+- We define a file which would contain vendor to module mapping and put it in a place which is accessible to both PMon container and host
+- The vendor to module mapping can be present in a file which could be present in sonic_platform_common
+- It makes sense to keep the mapping file in the sonic_y_cable package so that it can be updated in the same pull request when a vendor adds a new cable implementation. However, we cannot install data files outside of the Python directory via a wheel. Considering this we propose to make this a Python file which simply contains a 2D dictionary which can be used to look up the module path. If the file is part of the sonic_y_cable package, it will be installed in both the PMon container and the host
+
+For example
+```
+	/sonic_platform_common/sonic_y_cable/y_cable_vendor_mapping.py
+```
+
+Vendors can have several implementations/ways to use this concept
+- Vendor has a 1:1 mapping between model and Python file
+- Vendor has one Python file which supports all models
+- A combination of the above
+
+- Mapping could be such that its a dictionary in 2D
+```
+	<vendor_name>,<module>
+	<vendor_name>,<model_name>,<module>
+```
+- For example
+```
+	Credo,credo_model1,y_cable.py
+	Credo,y_cable.py
+```
+
+#### Rationale
+
+  - This is because both the container and host can easily access this path. And it would be easy to mount this on container (PMon container) as applicable.
+
+#### Implementation details
+- Once the xcvrd will start (daemon launched) it will know the Vendor name from the register specification and then it can appropriately read and parse the vendor name from the spec. Once it has this information it can then using this file Load/import the appropriate module.
+
 ### Directory Structure
 
 #### Background
 
-- We need to have an appropriate place where vendors can implement their modules/packages and provide Sonic with an abstraction layer where pmon and host can access the Y cable packages of all the vendors with ease
-   
-  - Currently the assumption is Y cable package implementation would be in python itself
-  - If a vendor provides shared library, that scenario would be considered accordingly
-  - Since sonic_y_cable (sonic-platform-common/sonic_y_cable) is already built as a package today (only for a single Y cable vendor with sonic-buildimage) vendors can also build packages along similar lines.
+- We need to have an appropriate place where vendors can implement their modules and provide SONiC with an abstraction layer where PMon container and host can access the Y cable packages of all the vendors with ease
+
+  - Currently the assumption is Y-cable API will be written in the Python language
+  - If a vendor has an existing library in a different language, they will need to either find a way to wrap/bind it in Python to align with the description below or (preferrably) provide a pure Python implementation
+  - Since sonic_y_cable (sonic-platform-common/sonic_y_cable) is already built as a package today (only for a single Y cable vendor with sonic-buildimage) vendors can also place their implementation in this directory itself.
 
 #### Proposed Solution
 
 - Vendors can place their implementations in this format
 
 ```
-	Sonic_platform_common/sonic_y_cable/<vendor>/y_cable.py
-```
-- For sxample
-
-```
-	Sonic_platform_common/sonic_y_cable/credo/y_cable.py
-```
-#### Rationale
-- The requirement here would be that the vendors must create their packages such that It can easily be accessed/imported and the packages also adhere to a uniform convention
-
-  - Vendor name should be derivable from the vendor name field inside the register spec of transceiver type.
-  - This is essential so that host/pmon can determine the vendor name from eeprom and import the module of the transceiver appropriately
-
-### Vendor to Module mapping
-
-#### Background
-
-- We need to have a vendor to Y cable module mappings defined and accessible somewhere for pmon/cli to import
-   
-  - Before calling any Y cable API, how do we know which type/vendor does the Y cable belong to ? 
-  - Also lets suppose once the type/vendor of the cable is known from where does pmon or cli import the module ?
-  - Since there can be many specs which vendors follow (8636, 8624 etc.) for transceivers it is important to have a solution which meets all requirements so that the API access is available to whoever wants to invoke it.
-  - another issue is how do we support the multiple vendors modules/packages which could be used by both sonic pmon docker as well as the sonic cli (sonic-utilities). Basically the package should be available both in host and container.
-#### Proposed Solution
-
-- We define a file which would contain vendor to module mapping and put it in a place which is accessible to both pmon and host
-- The vendor to module mapping can be present in a file which could be present in
-
-```
-	/usr/share/sonic/y_cable/y_cable_vendor_mapping.csv
-```
-or 
-
-```
-	/usr/share/sonic/y_cable/y_cable_vendor_mapping.yaml
-```
-- Mapping could be such that 
-```
-	<vendor_name>,<package_name>,<module>
+	sonic_platform_common/sonic_y_cable/<vendor>/y_cable.py
 ```
 - For example
-```
-	Credo,credo,y_cable
-```
 
+```
+	sonic_platform_common/sonic_y_cable/credo/y_cable.py
+```
 #### Rationale
+- The requirement here would be that the vendors must create their modules such that It can easily be accessed/imported and the modules also adhere to a uniform convention
 
-  - This is because both the container and host can easily access this path. And it would be easy to mount this on container (pmon) as applicable. 
-  - Also since python has built in support for both csv and yaml parsing, it would be convenient to retrieve the mappings.
+  - Vendor name should be derivable from the vendor name field inside the register spec of transceiver type.
+  - This is essential so that host/PMon container can determine the vendor name from eeprom and import the module of the transceiver appropriately
 
-#### Implementation details
-- Once the xcvrd will start (daemon launched) it will know the Vendor name from the register specification and then it can appropriately read and parse the vendor name from the spec. Once it has this information it can then using this file Load/import the appropriate module.
 
 ### Port to module mapping
 - Another thing that is required is once we do have a vendor to module mapping, we need to map appropriate port to a module as well
 
 #### Background
 
-  - Basically, the key idea is once we have a port identified as being of a certain vendor and it has been identified to load a certain module which we can gather from the mapping described above we still need to call the correct module on each port each time we call the API on the port 
-  - want to maintain this mapping in memory since xcvrd does not want to read/parse this y_cable_vendor_mapping.csv file again and again each time we call the y cable API 
+  - Basically, the key idea is once we have a port identified as being of a certain vendor and it has been identified to load a certain module which we can gather from the mapping described above we still need to call the correct module on each port each time we call the API on the port
+  - want to maintain this mapping in memory since xcvrd does not want to read/parse this y_cable_vendor_mapping.csv file again and again each time we call the y cable API
   - Also note that the module loaded might change during xcvrd running lifetime since cable can be changed from one vendor to another. So we need to take this into consideration as well
 
 #### Proposed Solution
@@ -99,11 +113,11 @@ or
 
 For example a typical module of the vendor can be like this
 ```
-        
+
 	class Ycable(Ycablebase):
             #all vendor modules inherit from Ycablebase
 	    def __init__(self):
-		
+
 	    def toggle_mux_to_torA(self, port):
 		#implement or raise exception if not implemented
 		raise NotImplementedError
@@ -120,15 +134,15 @@ For example a typical module of the vendor can be like this
 
 	    def only_amphenol(self, port):
 		raise NotImplementedError
-	
-```
-the base class would be like this 
 
-```   
+```
+the base class would be like this
+
+```
 	class Ycablebase(object):
 	    def __init__(self, port):
 		self.port = port
-		
+
 	    def toggle_mux_to_torA(self, port):
 		raise NotImplementedError
 	    def toggle_mux_to_torB(self, port):
@@ -154,7 +168,7 @@ the base class would be like this
 
 
 
-	# and to use the Y cable APIS 
+	# and to use the Y cable APIS
 	try:
 	    y_cable_port_etherne0.toggle_mux_to_torA()
 	except:
@@ -162,16 +176,16 @@ the base class would be like this
 ```
 #### Rationale
 
-  - xcvrd can maintain a dict of these objects an whenever it needs to call the API for the correct port (in this case physical port) it can easily achieve so by indexing into the instance of the physical port and calling the class object.  
+  - xcvrd can maintain a dict of these objects an whenever it needs to call the API for the correct port (in this case physical port) it can easily achieve so by indexing into the instance of the physical port and calling the class object.
 
 ```
 
-	Y_cable_ports_instances = {}  
-	  
-	# appending instances in the dictionary  
+	Y_cable_ports_instances = {}
+
+	# appending instances in the dictionary
 	Y_cable_ports_instances[physical_port] = Ycable(port)
 
-	# and to use the Y cable APIS 
+	# and to use the Y cable APIS
 	try:
 	    Y_cable_ports_instances[physical_port].toggle_mux_to_torA()
 	except:
@@ -184,15 +198,15 @@ the base class would be like this
 
 #### Background
 
-  - Another requirement we have is Cli also requires to interact with the Ycable directly. This basically implies that all  Ycable vendor packages needs to be imported inside sonic-utilities/host as well 
-  - This would come in the form of commands like setting PRBS, enabling disabling loopback and also get the BER info and EYE info etc 
-  - Also commands such as config/show hwmode is important which gives the cli ability to toggle the mux without going into sonic modules like mux-mgr or orchagent.
-  - All these require access to Y cable APIs to be directly called by the cli. But then again same problems arrive, how do we know which type/vendor does the cable/port belong to, how to load the appropriate module etc 
+  - Another requirement we have is Cli also requires to interact with the Ycable directly. This basically implies that all  Ycable vendor packages needs to be imported inside SONiC-utilities/host as well
+  - This would come in the form of commands like setting PRBS, enabling disabling loopback and also get the BER info and EYE info etc
+  - Also commands such as config/show hwmode is important which gives the cli ability to toggle the mux without going into SONiC modules like mux-mgr or orchagent.
+  - All these require access to Y cable APIs to be directly called by the cli. But then again same problems arrive, how do we know which type/vendor does the cable/port belong to, how to load the appropriate module etc
 
 #### Proposed Solution(s)
 
   - One way is since CLI lives in the host, we can choose to do everything on xcvrd lines. Meaning once there is port number, convert to a physical port and look into vendor to module mapping file and then load the module and execute the API
-  - Another way is cli can interact with pmon thorugh redis-db. Basically we can define a schema table for different operations which need to be performed on the y cable. 
+  - Another way is cli can interact with PMon container thorugh redis-db. Basically we can define a schema table for different operations which need to be performed on the y cable.
 
 ```
 	HW_MUX_OPERATION_TABLE|Ethernet0
@@ -201,26 +215,26 @@ the base class would be like this
 	check_mux_direction true/false
 ```
   - In xcvrd we can have a thread running and listening to these events and execute the APIs since all the ports already have the correct mapping of the module (maintained in the form of a dictionary). The response of the API can be again written back to the redis table and absorbed by the CLI
- 
-### Concurrency for Y cables API 
+
+### Concurrency for Y cables API
 
 #### Background
 
-  - Since some vendors need to execute two or three transactions in a single API it is imperative to have a solution where we can protect the Y cable APIs for concurrent behavior 
+  - Since some vendors need to execute two or three transactions in a single API it is imperative to have a solution where we can protect the Y cable APIs for concurrent behavior
 
 #### Proposed Solution(s)
 
   - We might need to pass a semaphore or lock to the API to protect reexecuting or executing some other API in the meantime.
   - For now we insist on vendors to acquire/release locks in the API/implementation itself. So that if there is any possibility of concurrency the locking mechanism inside the the API prevents that from happening
 
- 
-### Storing the state within a Y cable Module 
+
+### Storing the state within a Y cable Module
 
 #### Background
 
-  - Another requirement in future that could arise is what if we need a feature which requires vendors to store a state with the Y cable. In this regard it is important to address this requirement in the initial design itself. (example port to bus mapping) 
+  - Another requirement in future that could arise is what if we need a feature which requires vendors to store a state with the Y cable. In this regard it is important to address this requirement in the initial design itself. (example port to bus mapping)
 
 #### Proposed Solution(s)
 
-  - Since the vendor has class definitions associated with Y cable module, it can have attributes which store the information. However, it still needs to be decided how these attributes will be instantiated/configured. Whether this onus will be on xcvrd/daemon or whether it can be done within the module itself. 
+  - Since the vendor has class definitions associated with Y cable module, it can have attributes which store the information. However, it still needs to be decided how these attributes will be instantiated/configured. Whether this onus will be on xcvrd/daemon or whether it can be done within the module itself.
 

--- a/doc/y_cable/design_doc.md
+++ b/doc/y_cable/design_doc.md
@@ -161,10 +161,10 @@ Vendors can have several implementations/ways to use this concept
             def check_prbs(self, port):
                 <function body here>
 
-            def only_credo(self, port):
+            def enable_loopback(self, port):
                 <function body here>
 
-            def only_amphenol(self, port):
+            def get_eye_info(self, port):
                 <function body here>
 
     ```
@@ -186,10 +186,10 @@ Vendors can have several implementations/ways to use this concept
             def check_prbs(self, port):
                 <function body here>
 
-            def only_credo(self, port):
+            def enable_loopback(self, port):
                 <function body here>
 
-            def only_amphenol(self, port):
+            def get_eye_info(self, port):
                 <function body here>
 
     ```

--- a/doc/y_cable/design_doc.md
+++ b/doc/y_cable/design_doc.md
@@ -1,0 +1,225 @@
+## Multiple y cable vendor API design
+
+### Overview
+
+This document summarizes the approach taken to accommodate multiple
+Y cable vendors in Gemini Project. All the design choices are presented
+such that vendors can implement the Y cable interface with ease and effeciency
+and all the feature requirements are met.
+
+
+Challenge: to provide an interface for Y cable to interact with PMON docker and HOST
+           which can be uniform across all vendors.
+
+### Directory Structure
+
+#### Background
+
+- We need to have an appropriate place where vendors can implement their modules/packages and provide Sonic with an abstraction layer where pmon and host can access the Y cable packages of all the vendors with ease
+   
+  - Currently the assumption is Y cable package implementation would be in python itself
+  - If a vendor provides shared library, that scenario would be considered accordingly
+  - Since sonic_y_cable (sonic-platform-common/sonic_y_cable) is already built as a package today (only for a single Y cable vendor with sonic-buildimage) vendors can also build packages along similar lines.
+
+#### Proposed Solution
+
+- Vendors can place their implementations in this format
+
+```
+	Sonic_platform_common/sonic_y_cable/<vendor>/y_cable.py
+```
+- For sxample
+
+```
+	Sonic_platform_common/sonic_y_cable/credo/y_cable.py
+```
+#### Rationale
+- The requirement here would be that the vendors must create their packages such that It can easily be accessed/imported and the packages also adhere to a uniform convention
+
+  - Vendor name should be derivable from the vendor name field inside the register spec of transceiver type.
+  - This is essential so that host/pmon can determine the vendor name from eeprom and import the module of the transceiver appropriately
+
+### Vendor to Module mapping
+
+#### Background
+
+- We need to have a vendor to Y cable module mappings defined and accessible somewhere for pmon/cli to import
+   
+  - Before calling any Y cable API, how do we know which type/vendor does the Y cable belong to ? 
+  - Also lets suppose once the type/vendor of the cable is known from where does pmon or cli import the module ?
+  - Since there can be many specs which vendors follow (8636, 8624 etc.) for transceivers it is important to have a solution which meets all requirements so that the API access is available to whoever wants to invoke it.
+  - another issue is how do we support the multiple vendors modules/packages which could be used by both sonic pmon docker as well as the sonic cli (sonic-utilities). Basically the package should be available both in host and container.
+#### Proposed Solution
+
+- We define a file which would contain vendor to module mapping and put it in a place which is accessible to both pmon and host
+- The vendor to module mapping can be present in a file which could be present in
+
+```
+	/usr/share/sonic/y_cable/y_cable_vendor_mapping.csv
+```
+or 
+
+```
+	/usr/share/sonic/y_cable/y_cable_vendor_mapping.yaml
+```
+- Mapping could be such that 
+```
+	<vendor_name>,<package_name>,<module>
+```
+- For example
+```
+	Credo,credo,y_cable
+```
+
+#### Rationale
+
+  - This is because both the container and host can easily access this path. And it would be easy to mount this on container (pmon) as applicable. 
+  - Also since python has built in support for both csv and yaml parsing, it would be convenient to retrieve the mappings.
+
+#### Implementation details
+- Once the xcvrd will start (daemon launched) it will know the Vendor name from the register specification and then it can appropriately read and parse the vendor name from the spec. Once it has this information it can then using this file Load/import the appropriate module.
+
+### Port to module mapping
+- Another thing that is required is once we do have a vendor to module mapping, we need to map appropriate port to a module as well
+
+#### Background
+
+  - Basically, the key idea is once we have a port identified as being of a certain vendor and it has been identified to load a certain module which we can gather from the mapping described above we still need to call the correct module on each port each time we call the API on the port 
+  - want to maintain this mapping in memory since xcvrd does not want to read/parse this y_cable_vendor_mapping.csv file again and again each time we call the y cable API 
+  - Also note that the module loaded might change during xcvrd running lifetime since cable can be changed from one vendor to another. So we need to take this into consideration as well
+
+#### Proposed Solution
+
+  - Each module of the Y cable vendor can be a class (of each transceiver type) and all we need to do is instantiate the objects of these classes as class instances and these objects will provide the interface of calling the API's for the appropriate vendor Y cable.
+  - This instantiation will be done inside xcvrd, when xcvrd starts
+  - These objects basically emulate Y cable instances and whatever action/interaction needs to be done with the Ycable the methods of these objects would provide that
+  - each vendor in their implementation can inherit from a base class where there will be definitions for all the supported capabilities of the y cable.
+  - If the vendor does not support or implement the utility, it will just raise a not implemented error from the base class itself
+
+For example a typical module of the vendor can be like this
+```
+        
+	class Ycable(Ycablebase):
+            #all vendor modules inherit from Ycablebase
+	    def __init__(self):
+		
+	    def toggle_mux_to_torA(self, port):
+		#implement or raise exception if not implemented
+		raise NotImplementedError
+	    def toggle_mux_to_torB(self, port):
+		#implement or raise exception if not implemented
+		raise NotImplementedError
+
+	    def check_prbs(self, port):
+		#implement or raise exception if not implemented
+		raise NotImplementedError
+
+	    def only_credo(self, port):
+		raise NotImplementedError
+
+	    def only_amphenol(self, port):
+		raise NotImplementedError
+	
+```
+the base class would be like this 
+
+```   
+	class Ycablebase(object):
+	    def __init__(self, port):
+		self.port = port
+		
+	    def toggle_mux_to_torA(self, port):
+		raise NotImplementedError
+	    def toggle_mux_to_torB(self, port):
+		raise NotImplementedError
+
+	    def check_prbs(self, port):
+		raise NotImplementedError
+
+	    def only_credo(self, port):
+		raise NotImplementedError
+
+	    def only_amphenol(self, port):
+		raise NotImplementedError
+
+```
+
+#### Implementation details
+- Now for xcvrd to use this solution, all it has to do is instantiate the class objects defined by importing the appropriate module. This should happen when xcvrd starts or if there is a change event  (xcvrd inserted/removed)
+
+```
+	from credo import y_cable
+	y_cable_port_Ethernet0 = Ycable(port)
+
+
+
+	# and to use the Y cable APIS 
+	try:
+	    y_cable_port_etherne0.toggle_mux_to_torA()
+	except:
+	    helper_logger.log(not able to toggle_mux_to_torA)
+```
+#### Rationale
+
+  - xcvrd can maintain a dict of these objects an whenever it needs to call the API for the correct port (in this case physical port) it can easily achieve so by indexing into the instance of the physical port and calling the class object.  
+
+```
+
+	Y_cable_ports_instances = {}  
+	  
+	# appending instances in the dictionary  
+	Y_cable_ports_instances[physical_port] = Ycable(port)
+
+	# and to use the Y cable APIS 
+	try:
+	    Y_cable_ports_instances[physical_port].toggle_mux_to_torA()
+	except:
+	    helper_logger.log(not able to toggle_mux_to_torA)
+```
+
+
+### How does cli interact with Y cable api's
+- Another thing that is required is once we do have a vendor to module mapping, we need to map appropriate port to a module as well
+
+#### Background
+
+  - Another requirement we have is Cli also requires to interact with the Ycable directly. This basically implies that all  Ycable vendor packages needs to be imported inside sonic-utilities/host as well 
+  - This would come in the form of commands like setting PRBS, enabling disabling loopback and also get the BER info and EYE info etc 
+  - Also commands such as config/show hwmode is important which gives the cli ability to toggle the mux without going into sonic modules like mux-mgr or orchagent.
+  - All these require access to Y cable APIs to be directly called by the cli. But then again same problems arrive, how do we know which type/vendor does the cable/port belong to, how to load the appropriate module etc 
+
+#### Proposed Solution(s)
+
+  - One way is since CLI lives in the host, we can choose to do everything on xcvrd lines. Meaning once there is port number, convert to a physical port and look into vendor to module mapping file and then load the module and execute the API
+  - Another way is cli can interact with pmon thorugh redis-db. Basically we can define a schema table for different operations which need to be performed on the y cable. 
+
+```
+	HW_MUX_OPERATION_TABLE|Ethernet0
+	state active/standby
+	enable_prbs true/false
+	check_mux_direction true/false
+```
+  - In xcvrd we can have a thread running and listening to these events and execute the APIs since all the ports already have the correct mapping of the module (maintained in the form of a dictionary). The response of the API can be again written back to the redis table and absorbed by the CLI
+ 
+### Concurrency for Y cables API 
+
+#### Background
+
+  - Since some vendors need to execute two or three transactions in a single API it is imperative to have a solution where we can protect the Y cable APIs for concurrent behavior 
+
+#### Proposed Solution(s)
+
+  - We might need to pass a semaphore or lock to the API to protect reexecuting or executing some other API in the meantime.
+  - For now we insist on vendors to acquire/release locks in the API/implementation itself. So that if there is any possibility of concurrency the locking mechanism inside the the API prevents that from happening
+
+ 
+### Storing the state within a Y cable Module 
+
+#### Background
+
+  - Another requirement in future that could arise is what if we need a feature which requires vendors to store a state with the Y cable. In this regard it is important to address this requirement in the initial design itself. (example port to bus mapping) 
+
+#### Proposed Solution(s)
+
+  - Since the vendor has class definitions associated with Y cable module, it can have attributes which store the information. However, it still needs to be decided how these attributes will be instantiated/configured. Whether this onus will be on xcvrd/daemon or whether it can be done within the module itself. 
+

--- a/doc/y_cable/design_doc.md
+++ b/doc/y_cable/design_doc.md
@@ -39,11 +39,11 @@ Challenge: to provide an interface for Y cable to interact with PMON docker and 
 - We define a file which would contain a mapping from vendor/part number to the appropriate Y-cable module to load and put it in a place which is accessible to both PMon container and host which can be present in sonic_platform_common
 - It makes sense to keep the mapping file in the sonic_y_cable package so that it can be updated in the same pull request when a vendor adds a new cable implementation. However, we cannot install data files outside of the Python directory via a wheel. Considering this we propose to make this a Python file which simply contains a 2D dictionary which can be used to look up the module path. If the file is part of the sonic_y_cable package, it will be installed in both the PMon container and the host
 
-For example
-```
+###For example
 
-    /sonic_platform_common/sonic_y_cable/y_cable_vendor_mapping.py
-```
+    ```
+        /sonic_platform_common/sonic_y_cable/y_cable_vendor_mapping.py
+    ```
 
 Vendors can have several implementations/ways to use this concept
 - Vendor has a 1:1 mapping between model and Python file
@@ -52,32 +52,31 @@ Vendors can have several implementations/ways to use this concept
 
 - Mapping could be such that its a dictionary in 2D
 
-
-```python
+    ```python
     {
-         <vendor_name_1>: {
-             <model_name: <module>
+         "<vendor_name_1>": {
+             "<model_name>": "<module>"
          },
-         <vendor_name_2> : {
-             <model_name>: <module>
+         "<vendor_name_2>" : {
+             "<model_name>": "<module>"
          }
     }
-```
+    ```
 
-For example
+###For example
 
-```python
-   {
-        "Vendor1": {
+    ```python
+    {
+         "Vendor1": {
              "model1": "vendor1/y_cable.py"
-        },
+         },
 
- 	"Vendor2" : {
+         "Vendor2" : {
              "model_a": "vendor2/y_cable_a.py",
              "model_b": "vendor2/y_cable_b.py"
-        }
-   }
-```
+         }
+    }
+    ```
 
 #### Rationale
 
@@ -96,31 +95,32 @@ For example
   - Currently the assumption is Y-cable API will be written in the Python language
   - If a vendor has an existing library in a different language, they will need to either find a way to wrap/bind it in Python to align with the description below or (preferrably) provide a pure Python implementation
   - Since sonic_y_cable (sonic-platform-common/sonic_y_cable) is already built as a package today (only for a single Y cable vendor with sonic-buildimage) vendors can also place their implementation in this directory itself.
-  - Also, a vendor can provide multiple files to support multiple cables/groups of cables. Importing the module from the mappng should import all the necessary implementation for the cable
+  - Also, a vendor can provide multiple files to support multiple cables/groups of cables. Importing the module from the mapping should import all the necessary implementation for the cable
+  - Vendors can put their common implementation across multiple modules in helper files which can be present in the vendor directory or inside another subdirectory. The second example below shows this approach.
 
 #### Proposed Solution
 
 - Vendors can place their implementations in this format
 
-```
-	sonic_platform_common/sonic_y_cable/<vendor>/<module>
-```
+    ```
+    sonic_platform_common/sonic_y_cable/<vendor>/<module>
+    ```
 
-```
-	sonic_platform_common/sonic_y_cable/<vendor>/<module_1>
-	sonic_platform_common/sonic_y_cable/<vendor>/<module_2>
-```
+    ```
+    sonic_platform_common/sonic_y_cable/<vendor>/<module_1>
+    sonic_platform_common/sonic_y_cable/<vendor>/<module_2>
+    ```
 - Few examples
 
-```
-	sonic_platform_common/sonic_y_cable/vendor1/y_cable.py
-```
+    ```
+    sonic_platform_common/sonic_y_cable/vendor1/y_cable.py
+    ```
 
-```
-	sonic_platform_common/sonic_y_cable/vendor2/y_cable_xyz.py
-	sonic_platform_common/sonic_y_cable/vendor2/y_cable_abc.py
-	sonic_platform_common/sonic_y_cable/vendor2/abc_helper.py
-```
+    ```
+    sonic_platform_common/sonic_y_cable/vendor2/y_cable_xyz.py
+    sonic_platform_common/sonic_y_cable/vendor2/y_cable_abc.py
+    sonic_platform_common/sonic_y_cable/vendor2/abc_helper.py
+    ```
 #### Rationale
 - The requirement here would be that the vendors must create their modules such that It can easily be accessed/imported and the modules also adhere to a uniform convention
 
@@ -145,63 +145,63 @@ For example
   - each vendor in their implementation can inherit from a base class where there will be definitions for all the supported capabilities of the Y-cable.
   - for vendors the recommended approach in case their subclass implementation does not support a method, is to set the method equal to None. This differentiates it from a method they forgot to implement. Then, the calling code should first check if the method is None before attempting to call it.
 
-For example the base class would be like this
+###For example the base class would be like this
 
-```python
-	class YCableBase(object):
-	    def __init__(self, port):
-		self.port = port
+    ```python
+        class YCableBase(object):
+            def __init__(self, port):
+                self.port = port
                 <function body here>
 
-	    def toggle_mux_to_torA(self, port):
+            def toggle_mux_to_torA(self, port):
                 <function body here>
 
-	    def toggle_mux_to_torB(self, port):
+            def toggle_mux_to_torB(self, port):
                 <function body here>
 
-	    def check_prbs(self, port):
+            def check_prbs(self, port):
                 <function body here>
 
-	    def only_credo(self, port):
+            def only_credo(self, port):
                 <function body here>
 
-	    def only_amphenol(self, port):
+            def only_amphenol(self, port):
                 <function body here>
 
+    ```
 
-```
+###For example a typical module of the vendor can be like this
 
-For example a typical module of the vendor can be like this
-```python
-	class YCable(YCableBase):
+    ```python
+        class YCable(YCableBase):
 
-	    def __init__(self):
+            def __init__(self):
                 <function body here>
 
-	    def toggle_mux_to_torA(self, port):
+            def toggle_mux_to_torA(self, port):
                 <function body here>
 
-	    def toggle_mux_to_torB(self, port):
+            def toggle_mux_to_torB(self, port):
                 <function body here>
 
-	    def check_prbs(self, port):
+            def check_prbs(self, port):
                 <function body here>
 
-	    def only_credo(self, port):
+            def only_credo(self, port):
                 <function body here>
 
-	    def only_amphenol(self, port):
+            def only_amphenol(self, port):
                 <function body here>
 
-```
+    ```
 #### Implementation details
 - Now for xcvrd to use this solution, all it has to do is instantiate the class objects defined by importing the appropriate module. This should happen when xcvrd starts or if there is a change event  (xcvrd inserted/removed)
 
-```python
-        import importlib
+    ```python
         # import the vendor to module mapping
         from sonic_y_cable import y_cable_vendor_mapping
- 
+        from sonic_py_common.general import load_module_from_source
+
         # This vendor/part_name determination subroutines will either read through eeprom
         # or else read from the TRANSCEIVER_INFO_TABLE inside state db
 
@@ -209,11 +209,9 @@ For example a typical module of the vendor can be like this
 
         part_name = get_part_name(port)
 
-        module = y_cable_vendor_mapping.mapping[vendor_name][part_name]
+        path_to_module_obtained_from_mapping = y_cable_vendor_mapping.mapping[vendor_name][part_name]
 
-        from sonic_y_cable import module
-
-        importlib.reload(module)
+        module = load_module_from_source("y_cable",  "path_to_module_obtained_from_mapping")
 
         from module import YCable
 
@@ -225,12 +223,12 @@ For example a typical module of the vendor can be like this
         except:
             helper_logger.log(not able to toggle_mux_to_torA)
 
-```
+    ```
 #### Rationale
 
   - xcvrd can maintain a dict of these objects an whenever it needs to call the API for the correct port (in this case physical port) it can easily achieve so by indexing into the instance of the physical port and calling the class object.
 
-```python
+    ```python
         Y_cable_ports_instances = {}
 
         # appending instances in the dictionary
@@ -241,7 +239,7 @@ For example a typical module of the vendor can be like this
             Y_cable_ports_instances[physical_port].toggle_mux_to_torA()
         except:
             helper_logger.log(not able to toggle_mux_to_torA)
-```
+    ```
 
 
 ### How does cli interact with Y cable api's
@@ -249,7 +247,7 @@ For example a typical module of the vendor can be like this
 
 #### Background
 
-  - Another requirement we have is Cli also requires to interact with the Y-Cable directly. This basically implies that all  Ycable vendor packages needs to be imported inside SONiC-utilities/host as well
+  - Another requirement we have is Cli also requires to interact with the Y-Cable directly. This basically implies that all  Y-Cable vendor packages needs to be imported inside SONiC-utilities/host as well
   - This would come in the form of commands like setting PRBS, enabling disabling loopback and also get the BER info and EYE info etc
   - Also commands such as config/show hwmode is important which gives the cli ability to toggle the mux without going into SONiC modules like mux-mgr or orchagent.
   - All these require access to Y cable APIs to be directly called by the cli. But then again same problems arrive, how do we know which type/vendor does the cable/port belong to, how to load the appropriate module etc
@@ -260,12 +258,12 @@ For example a typical module of the vendor can be like this
   - The more preferred approach here is cli can interact with PMon container thorugh redis-db. Basically we can define a schema table for different operations which need to be performed on the Y-cable. 
 
 Exanple table and operations
-```
-	HW_MUX_OPERATION_TABLE|Ethernet0
-	state active/standby
-	enable_prbs true/false
-	check_mux_direction true/false
-```
+    ```
+        HW_MUX_OPERATION_TABLE|Ethernet0
+        state active/standby
+        enable_prbs true/false
+        check_mux_direction true/false
+    ```
   - In xcvrd we can have a thread running and listening to these events and execute the APIs since all the ports already have the correct mapping of the module (maintained in the form of a dictionary). The response of the API can be again written back to the redis table and absorbed by the CLI
 
 ### Concurrency for Y cables API

--- a/doc/y_cable/design_doc.md
+++ b/doc/y_cable/design_doc.md
@@ -1,4 +1,4 @@
-## Multiple Y-cable vendor API design
+## Multiple Y-Cable vendor API design
 
 ## Revision
 
@@ -11,13 +11,13 @@
 ### Overview
 
 This document summarizes the approach taken to accommodate multiple
-Y cable vendors for supporting dual-ToR configurations in SONiC.
+Y-Cable vendors for supporting dual-ToR configurations in SONiC.
 All the design choices are presented
-such that vendors can implement the Y cable interface with ease and effeciency
+such that vendors can implement the Y-Cable interface with ease and effeciency
 and all the feature requirements are met.
 
 
-Challenge: to provide an interface for Y cable to interact with PMON docker and HOST
+Challenge: to provide an interface for Y-Cable to interact with PMON docker and HOST
            which can be uniform across all vendors. As part of this refactor, we will
            be moving towards a model where only xcvrd interacts with the cables/transceivers, 
            and host-side processes will communicate with xcvrd rather than with the devices directly
@@ -27,16 +27,16 @@ Challenge: to provide an interface for Y cable to interact with PMON docker and 
 
 #### Background
 
-- We need to have a vendor to corresponding Y cable module mappings defined and accessible somewhere for PMon container to import
+- We need to have a vendor to corresponding Y-Cable module mappings defined and accessible somewhere for PMon container to import
 
-  - Before calling any Y cable API, how do we know which type/vendor does the Y cable belong to ?
-  - Also lets suppose once the type/vendor of the cable is known from where does interested application import the module ?
+  - Before calling any Y-Cable API, how do we know which type/vendor does the Y-Cable belong to?
+  - Also lets suppose once the type/vendor of the cable is known from where does interested application import the module?
   - Since there can be many specs which vendors follow (8636, 8624 etc.) for transceivers it is important to have a solution which meets all requirements so that the API access is available to whoever wants to invoke it.
-  - another issue is how do we support the multiple vendors modules/packages which could be used by both SONiC PMon container docker as well as the sonic cli (sonic-utilities). Basically the package should be available both in host and container. Although we are moving towards a model where cli should not need to import Y cable modules but it is still preferred have it accessible
+  - another issue is how do we support the multiple vendors modules/packages which could be used by both SONiC PMon container docker as well as the SONiC CLI (sonic-utilities). Basically the package should be available both in host and container. Although we are moving towards a model where CLI should not need to import Y-Cable modules but it is still preferred have it accessible
 
 #### Proposed Solution
 
-- We define a file which would contain a mapping from vendor/part number to the appropriate Y-cable module to load and put it in a place which is accessible to both PMon container and host which can be present in sonic_platform_common
+- We define a file which would contain a mapping from vendor/part number to the appropriate Y-Cable module to load and put it in a place which is accessible to both PMon container and host which can be present in sonic_platform_common
 - It makes sense to keep the mapping file in the sonic_y_cable package so that it can be updated in the same pull request when a vendor adds a new cable implementation. However, we cannot install data files outside of the Python directory via a wheel. Considering this we propose to make this a Python file which simply contains a 2D dictionary which can be used to look up the module path. If the file is part of the sonic_y_cable package, it will be installed in both the PMon container and the host
 
 - For example
@@ -89,11 +89,11 @@ Vendors can have several implementations/ways to use this concept
 
 #### Background
 
-- We need to have an appropriate place where vendors can implement their modules and provide SONiC with an abstraction layer where PMon container and host can access the Y cable packages of all the vendors with ease
+- We need to have an appropriate place where vendors can implement their modules and provide SONiC with an abstraction layer where PMon container and host can access the Y-Cable packages of all the vendors with ease
 
-  - Currently the assumption is Y-cable API will be written in the Python language
+  - Currently the assumption is Y-Cable API will be written in the Python language
   - If a vendor has an existing library in a different language, they will need to either find a way to wrap/bind it in Python to align with the description below or (preferrably) provide a pure Python implementation
-  - Since sonic_y_cable (sonic-platform-common/sonic_y_cable) is already built as a package today (only for a single Y cable vendor with sonic-buildimage) vendors can also place their implementation in this directory itself.
+  - Since sonic_y_cable (sonic-platform-common/sonic_y_cable) is already built as a package today (only for a single Y-Cable vendor with sonic-buildimage) vendors can also place their implementation in this directory itself.
   - Also, a vendor can provide multiple files to support multiple cables/groups of cables. Importing the module from the mapping should import all the necessary implementation for the cable
   - Vendors can put their common implementation across multiple modules in helper files which can be present in the vendor directory or inside another subdirectory. The second example below shows this approach.
 
@@ -128,20 +128,20 @@ Vendors can have several implementations/ways to use this concept
 
 
 ### Port to module mapping
-- Another thing that is required is once we do have a mapping from vendor/part number to the appropriate Y-cable module to load, we need to map appropriate port to a module as well
+- Another thing that is required is once we do have a mapping from vendor/part number to the appropriate Y-Cable module to load, we need to map appropriate port to a module as well
 
 #### Background
 
   - Basically, the key idea is once we have a port identified as being of a certain vendor and it has been identified to load a certain module which we can gather from the mapping described above we still need to call the correct module on each port each time we call the API on the port
-  - want to maintain this mapping in memory since xcvrd does not want to read/parse this y_cable_vendor_mapping.csv file again and again each time we call the Y-cable API
+  - want to maintain this mapping in memory since xcvrd does not want to read/parse this y_cable_vendor_mapping.py file again and again each time we call the Y-Cable API
   - Also note that the module loaded might change during xcvrd running lifetime since cable can be changed from one vendor to another. So we need to take this into consideration as well
 
 #### Proposed Solution
 
-  - Each module of the Y cable vendor can be a class (of each transceiver type) and all we need to do is instantiate the objects of these classes as class instances and these objects will provide the interface of calling the API's for the appropriate vendor Y cable.
+  - Each module of the Y-Cable vendor can be a class (of each transceiver type) and all we need to do is instantiate the objects of these classes as class instances and these objects will provide the interface of calling the API's for the appropriate vendor Y-Cable.
   - This instantiation will be done inside xcvrd, when xcvrd starts
-  - These objects basically emulate Y cable instances and whatever action/interaction needs to be done with the Y-Cable the methods of these objects would provide that
-  - each vendor in their implementation can inherit from a base class where there will be definitions for all the supported capabilities of the Y-cable.
+  - These objects basically emulate Y-Cable instances and whatever action/interaction needs to be done with the Y-Cable the methods of these objects would provide that
+  - each vendor in their implementation can inherit from a base class where there will be definitions for all the supported capabilities of the Y-Cable.
   - for vendors the recommended approach in case their subclass implementation does not support a method, is to set the method equal to None. This differentiates it from a method they forgot to implement. Then, the calling code should first check if the method is None before attempting to call it.
 
   - For example the base class would be like this
@@ -216,7 +216,7 @@ Vendors can have several implementations/ways to use this concept
 
         y_cable_port_Ethernet0 = YCable(port)
 
-        # and to use the Y cable APIS
+        # and to use the Y-Cable APIS
         try:
             y_cable_port_Etherne0.toggle_mux_to_torA()
         except:
@@ -233,7 +233,7 @@ Vendors can have several implementations/ways to use this concept
         # appending instances in the dictionary
         Y_cable_ports_instances[physical_port] = YCable(port)
 
-        # and to use the Y cable APIS
+        # and to use the Y-Cable APIS
         try:
             Y_cable_ports_instances[physical_port].toggle_mux_to_torA()
         except:
@@ -241,20 +241,20 @@ Vendors can have several implementations/ways to use this concept
     ```
 
 
-### How does cli interact with Y cable api's
-- Another thing that is required is once we do have a a mapping from vendor/part number to the appropriate Y-cable module to load, we need to map appropriate port to a module as well
+### How does SONiC CLI interact with Y-Cable API's
+- Another thing that is required is once we do have a a mapping from vendor/part number to the appropriate Y-Cable module to load, we need to map appropriate port to a module as well
 
 #### Background
 
-  - Another requirement we have is Cli also requires to interact with the Y-Cable directly. This basically implies that all  Y-Cable vendor packages needs to be imported inside SONiC-utilities/host as well
+  - Another requirement we have is SONiC CLI also requires to interact with the Y-Cable directly. This basically implies that all  Y-Cable vendor packages needs to be imported inside SONiC-utilities/host as well
   - This would come in the form of commands like setting PRBS, enabling disabling loopback and also get the BER info and EYE info etc
-  - Also commands such as config/show hwmode is important which gives the cli ability to toggle the mux without going into SONiC modules like mux-mgr or orchagent.
-  - All these require access to Y cable APIs to be directly called by the cli. But then again same problems arrive, how do we know which type/vendor does the cable/port belong to, how to load the appropriate module etc
+  - Also commands such as config/show hwmode is important which gives the CLI ability to toggle the mux without going into SONiC modules like mux-mgr or orchagent.
+  - All these require access to Y-Cable APIs to be directly called by the CLI. But then again same problems arrive, how do we know which type/vendor does the cable/port belong to, how to load the appropriate module etc
 
 #### Proposed Solution(s)
 
-  - One way is since CLI lives in the host, we can choose to do everything on xcvrd lines. Meaning once there is port number, convert to a physical port and look into a mapping from vendor/part number to the appropriate Y-cable module to load file and then load the module and execute the API
-  - The more preferred approach here is cli can interact with PMon container thorugh redis-db. Basically we can define a schema table for different operations which need to be performed on the Y-cable. 
+  - One way is since CLI lives in the host, we can choose to do everything on xcvrd lines. Meaning once there is port number, convert to a physical port and look into a mapping from vendor/part number to the appropriate Y-Cable module to load file and then load the module and execute the API
+  - The more preferred approach here is CLI can interact with PMon container thorugh redis-db. Basically we can define a schema table for different operations which need to be performed on the Y-Cable. 
 
   - Exanple table and operations
     ```
@@ -265,11 +265,11 @@ Vendors can have several implementations/ways to use this concept
     ```
   - In xcvrd we can have a thread running and listening to these events and execute the APIs since all the ports already have the correct mapping of the module (maintained in the form of a dictionary). The response of the API can be again written back to the redis table and absorbed by the CLI
 
-### Concurrency for Y cables API
+### Concurrency for Y-Cables API
 
 #### Background
 
-  - Since some vendors need to execute two or three transactions in a single API it is imperative to have a solution where we can protect the Y cable APIs for concurrent behavior
+  - Since some vendors need to execute two or three transactions in a single API it is imperative to have a solution where we can protect the Y-Cable APIs for concurrent behavior
 
 #### Proposed Solution(s)
 
@@ -277,13 +277,13 @@ Vendors can have several implementations/ways to use this concept
   - For now we insist on vendors to acquire/release locks in the API/implementation itself. So that if there is any possibility of concurrency the locking mechanism inside the the API prevents that from happening
 
 
-### Storing the state within a Y cable Module
+### Storing the state within a Y-Cable Module
 
 #### Background
 
-  - Another requirement in future that could arise is what if we need a feature which requires vendors to store a state with the Y cable. In this regard it is important to address this requirement in the initial design itself. (example port to bus mapping)
+  - Another requirement in future that could arise is what if we need a feature which requires vendors to store a state with the Y-Cable. In this regard it is important to address this requirement in the initial design itself. (example port to bus mapping)
 
 #### Proposed Solution(s)
 
-  - Since the vendor has class definitions associated with Y cable module, it can have attributes which store the information. However, it still needs to be decided how these attributes will be instantiated/configured. Whether this onus will be on xcvrd/daemon or whether it can be done within the module itself.
+  - Since the vendor has class definitions associated with Y-Cable module, it can have attributes which store the information. However, it still needs to be decided how these attributes will be instantiated/configured. Whether this onus will be on xcvrd/daemon or whether it can be done within the module itself.
 

--- a/doc/y_cable/design_doc.md
+++ b/doc/y_cable/design_doc.md
@@ -3,7 +3,8 @@
 ### Overview
 
 This document summarizes the approach taken to accommodate multiple
-Y cable vendors in Gemini Project. All the design choices are presented
+Y cable vendors for supporting dual-ToR configurations in SONiC.
+All the design choices are presented
 such that vendors can implement the Y cable interface with ease and effeciency
 and all the feature requirements are met.
 

--- a/doc/y_cable/design_doc.md
+++ b/doc/y_cable/design_doc.md
@@ -1,4 +1,4 @@
-## Multiple y cable vendor API design
+## Multiple Y-cable vendor API design
 
 ## Revision
 
@@ -31,6 +31,7 @@ Challenge: to provide an interface for Y cable to interact with PMON docker and 
   - Also lets suppose once the type/vendor of the cable is known from where does PMon container or cli import the module ?
   - Since there can be many specs which vendors follow (8636, 8624 etc.) for transceivers it is important to have a solution which meets all requirements so that the API access is available to whoever wants to invoke it.
   - another issue is how do we support the multiple vendors modules/packages which could be used by both SONiC PMon container docker as well as the sonic cli (sonic-utilities). Basically the package should be available both in host and container.
+
 #### Proposed Solution
 
 - We define a file which would contain vendor to module mapping and put it in a place which is accessible to both PMon container and host
@@ -48,6 +49,9 @@ Vendors can have several implementations/ways to use this concept
 - A combination of the above
 
 - Mapping could be such that its a dictionary in 2D
+
+For example
+
 ```
 	<vendor_name>,<module>
 	<vendor_name>,<model_name>,<module>
@@ -100,7 +104,7 @@ Vendors can have several implementations/ways to use this concept
 #### Background
 
   - Basically, the key idea is once we have a port identified as being of a certain vendor and it has been identified to load a certain module which we can gather from the mapping described above we still need to call the correct module on each port each time we call the API on the port
-  - want to maintain this mapping in memory since xcvrd does not want to read/parse this y_cable_vendor_mapping.csv file again and again each time we call the y cable API
+  - want to maintain this mapping in memory since xcvrd does not want to read/parse this y_cable_vendor_mapping.csv file again and again each time we call the Y-cable API
   - Also note that the module loaded might change during xcvrd running lifetime since cable can be changed from one vendor to another. So we need to take this into consideration as well
 
 #### Proposed Solution
@@ -108,7 +112,7 @@ Vendors can have several implementations/ways to use this concept
   - Each module of the Y cable vendor can be a class (of each transceiver type) and all we need to do is instantiate the objects of these classes as class instances and these objects will provide the interface of calling the API's for the appropriate vendor Y cable.
   - This instantiation will be done inside xcvrd, when xcvrd starts
   - These objects basically emulate Y cable instances and whatever action/interaction needs to be done with the Ycable the methods of these objects would provide that
-  - each vendor in their implementation can inherit from a base class where there will be definitions for all the supported capabilities of the y cable.
+  - each vendor in their implementation can inherit from a base class where there will be definitions for all the supported capabilities of the Y-cable.
   - If the vendor does not support or implement the utility, it will just raise a not implemented error from the base class itself
 
 For example a typical module of the vendor can be like this
@@ -206,7 +210,7 @@ the base class would be like this
 #### Proposed Solution(s)
 
   - One way is since CLI lives in the host, we can choose to do everything on xcvrd lines. Meaning once there is port number, convert to a physical port and look into vendor to module mapping file and then load the module and execute the API
-  - Another way is cli can interact with PMon container thorugh redis-db. Basically we can define a schema table for different operations which need to be performed on the y cable.
+  - Another way is cli can interact with PMon container thorugh redis-db. Basically we can define a schema table for different operations which need to be performed on the Y-cable.
 
 ```
 	HW_MUX_OPERATION_TABLE|Ethernet0

--- a/doc/y_cable/design_doc.md
+++ b/doc/y_cable/design_doc.md
@@ -69,7 +69,7 @@ Vendors can have several implementations/ways to use this concept
   - The sonic_y_cable package is installed in both host and pmon
 
 #### Implementation details
-- Once the xcvrd will start (daemon launched) it will know the Vendor name from the register specification and then it can appropriately read and parse the vendor name from the spec. Once it has this information it can then using this file to Load/import the appropriate module.
+- Once the xcvrd will start (daemon launched) or tranceiver is connected (plugged in), in both cases xcvrd can determine the Vendor name and part number from the register specification and then it can appropriately read and parse the vendor name and part number from the spec using eeprom. Once it has this information it can then use this file to Load/import the appropriate module.
 
 ### Directory Structure
 

--- a/doc/y_cable/design_doc.md
+++ b/doc/y_cable/design_doc.md
@@ -40,8 +40,9 @@ Challenge: to provide an interface for Y cable to interact with PMON docker and 
 - It makes sense to keep the mapping file in the sonic_y_cable package so that it can be updated in the same pull request when a vendor adds a new cable implementation. However, we cannot install data files outside of the Python directory via a wheel. Considering this we propose to make this a Python file which simply contains a 2D dictionary which can be used to look up the module path. If the file is part of the sonic_y_cable package, it will be installed in both the PMon container and the host
 
 For example
-```
-	/sonic_platform_common/sonic_y_cable/y_cable_vendor_mapping.py
+```python
+
+    /sonic_platform_common/sonic_y_cable/y_cable_vendor_mapping.py
 ```
 
 Vendors can have several implementations/ways to use this concept
@@ -52,7 +53,8 @@ Vendors can have several implementations/ways to use this concept
 - Mapping could be such that its a dictionary in 2D
 
 
- ```python
+```python
+
     {
          <vendor_name_1>: {
              <model_name: <module>
@@ -61,9 +63,10 @@ Vendors can have several implementations/ways to use this concept
              <model_name>: <module>
          }
     }
- ```
+```
 
-- For example
+For example
+
 ```python
 
    {
@@ -210,33 +213,33 @@ For example a typical module of the vendor can be like this
         part_name = get_part_name(port)
 
         module = y_cable_vendor_mapping.mapping[vendor_name][part_name]
-        
-	from sonic_y_cable import vendor_name.part_name.module.YCable as YCable
 
-	y_cable_port_Ethernet0 = YCable(port)
+        from sonic_y_cable import vendor_name.part_name.module.YCable as YCable
 
-	# and to use the Y cable APIS
-	try:
-	    y_cable_port_Etherne0.toggle_mux_to_torA()
-	except:
-	    helper_logger.log(not able to toggle_mux_to_torA)
+        y_cable_port_Ethernet0 = YCable(port)
+
+        # and to use the Y cable APIS
+        try:
+            y_cable_port_Etherne0.toggle_mux_to_torA()
+        except:
+            helper_logger.log(not able to toggle_mux_to_torA)
+
 ```
 #### Rationale
 
   - xcvrd can maintain a dict of these objects an whenever it needs to call the API for the correct port (in this case physical port) it can easily achieve so by indexing into the instance of the physical port and calling the class object.
 
 ```python
+        Y_cable_ports_instances = {}
 
-	Y_cable_ports_instances = {}
+        # appending instances in the dictionary
+        Y_cable_ports_instances[physical_port] = YCable(port)
 
-	# appending instances in the dictionary
-	Y_cable_ports_instances[physical_port] = YCable(port)
-
-	# and to use the Y cable APIS
-	try:
-	    Y_cable_ports_instances[physical_port].toggle_mux_to_torA()
-	except:
-	    helper_logger.log(not able to toggle_mux_to_torA)
+        # and to use the Y cable APIS
+        try:
+            Y_cable_ports_instances[physical_port].toggle_mux_to_torA()
+        except:
+            helper_logger.log(not able to toggle_mux_to_torA)
 ```
 
 

--- a/doc/y_cable/design_doc.md
+++ b/doc/y_cable/design_doc.md
@@ -39,8 +39,7 @@ Challenge: to provide an interface for Y cable to interact with PMON docker and 
 - We define a file which would contain a mapping from vendor/part number to the appropriate Y-cable module to load and put it in a place which is accessible to both PMon container and host which can be present in sonic_platform_common
 - It makes sense to keep the mapping file in the sonic_y_cable package so that it can be updated in the same pull request when a vendor adds a new cable implementation. However, we cannot install data files outside of the Python directory via a wheel. Considering this we propose to make this a Python file which simply contains a 2D dictionary which can be used to look up the module path. If the file is part of the sonic_y_cable package, it will be installed in both the PMon container and the host
 
-###For example
-
+- For example
     ```
         /sonic_platform_common/sonic_y_cable/y_cable_vendor_mapping.py
     ```
@@ -63,7 +62,7 @@ Vendors can have several implementations/ways to use this concept
     }
     ```
 
-###For example
+- For example
 
     ```python
     {
@@ -145,7 +144,7 @@ Vendors can have several implementations/ways to use this concept
   - each vendor in their implementation can inherit from a base class where there will be definitions for all the supported capabilities of the Y-cable.
   - for vendors the recommended approach in case their subclass implementation does not support a method, is to set the method equal to None. This differentiates it from a method they forgot to implement. Then, the calling code should first check if the method is None before attempting to call it.
 
-###For example the base class would be like this
+  - For example the base class would be like this
 
     ```python
         class YCableBase(object):
@@ -170,7 +169,7 @@ Vendors can have several implementations/ways to use this concept
 
     ```
 
-###For example a typical module of the vendor can be like this
+  - For example a typical module of the vendor can be like this
 
     ```python
         class YCable(YCableBase):
@@ -257,7 +256,7 @@ Vendors can have several implementations/ways to use this concept
   - One way is since CLI lives in the host, we can choose to do everything on xcvrd lines. Meaning once there is port number, convert to a physical port and look into a mapping from vendor/part number to the appropriate Y-cable module to load file and then load the module and execute the API
   - The more preferred approach here is cli can interact with PMon container thorugh redis-db. Basically we can define a schema table for different operations which need to be performed on the Y-cable. 
 
-Exanple table and operations
+  - Exanple table and operations
     ```
         HW_MUX_OPERATION_TABLE|Ethernet0
         state active/standby

--- a/doc/y_cable/design_doc.md
+++ b/doc/y_cable/design_doc.md
@@ -69,7 +69,7 @@ Vendors can have several implementations/ways to use this concept
   - The sonic_y_cable package is installed in both host and pmon
 
 #### Implementation details
-- Once the xcvrd will start (daemon launched) or tranceiver is connected (plugged in), in both cases xcvrd can determine the Vendor name and part number from the register specification and then it can appropriately read and parse the vendor name and part number from the spec using eeprom. Once it has this information it can then use this file to Load/import the appropriate module.
+- Once the xcvrd will start (daemon launched) or transceiver is connected (plugged in), in both cases xcvrd can determine the Vendor name and part number from the register specification and then it can appropriately read and parse the vendor name and part number from the spec using eeprom. Once it has this information it can then use this file to Load/import the appropriate module.
 
 ### Directory Structure
 


### PR DESCRIPTION
| PR title | state | context |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| [[sonic-platform-common] Abstract Class support for multiple vendors for muxcable](https://github.com/Azure/sonic-platform-common/pull/186) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-platform-common/186) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-platform-common/186) |
| [[sonic-platform-common][Credo] Credo implementation for Abstract Class support for muxcable ](https://github.com/Azure/sonic-platform-common/pull/203) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-platform-common/203) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-platform-common/203) |
| [[sonic-platform-common][Broadcom] Broadcom implementation for Abstract Class support for muxcable ](https://github.com/Azure/sonic-platform-common/pull/208) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-platform-common/208) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-platform-common/208) |
| [[sonic-platform-daemons][XCVRD] xcvrd changes for Abstract Class support for muxcable ](https://github.com/Azure/sonic-platform-daemons/pull/197) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-platform-daemons/197) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-platform-daemons/197) |
| [[sonic-utilities][show][config] cli refactor for Abstract Class support for muxcable ](https://github.com/Azure/sonic-utilities/pull/1722) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-utilities/1722) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-utilities/1722) |
| [[sonic-buildimage]  fwfiles mount support for PMON](https://github.com/Azure/sonic-buildimage/pull/8283) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-buildimage/8283) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-buildimage/8283) |
| [[sonic-platform-common]  mux-simulator support for sonic-platform-common](https://github.com/Azure/sonic-platform-common/pull/213) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-platform-common/213) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-platform-common/213) |
| [[sonic-mgmt]  mux-simulator support for sonic-mgmt](https://github.com/Azure/sonic-mgmt/pull/4106) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-mgmt/4106) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-mgmt/4106) |

