### PR TITLE
Adjust the HLD for error status

### DIFF
--- a/doc/xrcvd/transceiver-monitor-hld.md
+++ b/doc/xrcvd/transceiver-monitor-hld.md
@@ -12,33 +12,32 @@
 This document is intend to provide general information about the Transceiver and Sensor Monitoring implementation.
 The requirement is described in [Sensor and Transceiver Info Monitoring Requirement.](https://github.com/Azure/SONiC/blob/master/doc/xrcvd/OIDsforSensorandTransciver.MD)
 
-
 ## 1. Xcvrd design ##
 
-New Xcvrd in platform monitor container is designed to fetch the transceiver and DOM sensor information from the eeprom and then update the state db with these info. 
+New Xcvrd in platform monitor container is designed to fetch the transceiver and DOM sensor information from the eeprom and then update the state db with these info.
 
 For the transceiver it's self, the type, serial number, hardware version, etc. will not change after plug in. The suitable way for transceiver information update can be triggered by transceiver plug in/out event.
 
 The transceiver dom sensor information(temperature, power,voltage, etc.) can change frequently, these information need to be updated periodically, for now the time period temporarily set to 60s(see open question 1), this time period need to be adjusted according the later on test on all vendors platform.
 
-If there is transceiver plug in or plug out, Xcvrd will respond to the change event, write the new transceiver EEPROM into to state DB, or remove the staled info from the STATE_DB. 
+If there is transceiver plug in or plug out, Xcvrd will respond to the change event, write the new transceiver EEPROM into to state DB, or remove the staled info from the STATE_DB.
 
 Transceiver error event will also be handled when it raised to Xcvrd, currently if transceiver on a error status which blocking EEPROM access, Xcvrd will stop updating and remove the transceiver DOM info from DB until it recovered from the error, in this period transceiver static info will be kept.  
- 
+
 ### 1.1 State DB Schema ###
 
 New Transceiver info table and transceiver DOM sensor table will be added to state DB to store the transceiver and DOM sensor information. Transceiver status table will store the SFP status, plug in, plug out or in error status.
 
 #### 1.1.1 Transceiver info Table ####
 
-	; Defines Transceiver information for a port
-	key                          = TRANSCEIVER_INFO|ifname      ; information for SFP on port
-	; field                      = value
-	type                         = 1*255VCHAR                   ; type of sfp
-	hardwarerev                  = 1*255VCHAR                   ; hardware version of sfp
-	serialnum                    = 1*255VCHAR                   ; serial number of the sfp
-	manufacturename              = 1*255VCHAR                   ; sfp venndor name
-	modelname                    = 1*255VCHAR                   ; sfp model name
+    ; Defines Transceiver information for a port
+    key                          = TRANSCEIVER_INFO|ifname      ; information for SFP on port
+    ; field                      = value
+    type                         = 1*255VCHAR                   ; type of sfp
+    hardwarerev                  = 1*255VCHAR                   ; hardware version of sfp
+    serialnum                    = 1*255VCHAR                   ; serial number of the sfp
+    manufacturename              = 1*255VCHAR                   ; sfp venndor name
+    modelname                    = 1*255VCHAR                   ; sfp model name
     vendor_oui                   = 1*255VCHAR                   ; vendor organizationally unique identifier
     vendor_date                  = 1*255VCHAR                   ; vendor's date code
     Connector                    = 1*255VCHAR                   ; connector type
@@ -52,18 +51,18 @@ New Transceiver info table and transceiver DOM sensor table will be added to sta
 
 #### 1.1.2 Transceiver DOM sensor Table ####
 
-	; Defines Transceiver DOM sensor information for a port
-	key                     = TRANSCEIVER_DOM_SENSOR|ifname      ; information SFP DOM sensors on port
-	temperature             = FLOAT                              ; temperature value in Celsius
-	voltage                 = FLOAT                              ; voltage value
-	rx1power                = FLOAT                              ; rx1 power in dbm
-	rx2power                = FLOAT                              ; rx2 power in dbm
-	rx3power                = FLOAT                              ; rx3 power in dbm
-	rx4power                = FLOAT                              ; rx4 power in dbm
-	tx1bias                 = FLOAT                              ; tx1 bias in mA
-	tx2bias                 = FLOAT                              ; tx2 bias in mA
-	tx3bias                 = FLOAT                              ; tx3 bias in mA
-	tx4bias                 = FLOAT                              ; tx4 bias in mA
+    ; Defines Transceiver DOM sensor information for a port
+    key                     = TRANSCEIVER_DOM_SENSOR|ifname      ; information SFP DOM sensors on port
+    temperature             = FLOAT                              ; temperature value in Celsius
+    voltage                 = FLOAT                              ; voltage value
+    rx1power                = FLOAT                              ; rx1 power in dbm
+    rx2power                = FLOAT                              ; rx2 power in dbm
+    rx3power                = FLOAT                              ; rx3 power in dbm
+    rx4power                = FLOAT                              ; rx4 power in dbm
+    tx1bias                 = FLOAT                              ; tx1 bias in mA
+    tx2bias                 = FLOAT                              ; tx2 bias in mA
+    tx3bias                 = FLOAT                              ; tx3 bias in mA
+    tx4bias                 = FLOAT                              ; tx4 bias in mA
     temphighalarm           = FLOAT                              ; temperature high alarm threshold 
     temphighwarning         = FLOAT                              ; temperature high warning threshold
     templowalarm            = FLOAT                              ; temperature low alarm threshold
@@ -91,17 +90,15 @@ New Transceiver info table and transceiver DOM sensor table will be added to sta
         key                          = TRANSCEIVER_STATUS|ifname     ; Error information for SFP on port
         ; field                      = value
         status                       = 1*255VCHAR                    ; code of the SFP status (plug in, plug out)
-        error                        = 1*255VCHAR                    ; SFP error (N/A or a string like error1 | error2 )
-
+        error                        = 1*255VCHAR                    ; SFP error (N/A or a string consisting of error descriptions joined by "|", like "error1 | error2" )
 
 ### 1.2 Accessing EEPROM from platform container ###
 
-Transceiver EEPROM information can be accessed via reading sysfs files(e.g. `/sys/bus/i2c/devices/2-0048/hwmon/hwmon4/qsfp9_eeprom`) or other ways, this is upon vendor's own implementation. 
+Transceiver EEPROM information can be accessed via reading sysfs files(e.g. `/sys/bus/i2c/devices/2-0048/hwmon/hwmon4/qsfp9_eeprom`) or other ways, this is upon vendor's own implementation.
 
-Transceiver EEPROM accessing can be achieved by legacy sfputil.py plugin or new platform API, Xcvrd supports both of these two methods. If platform API not yet implemented on some vendor's device, it will automatically fall back on sfputil.py plugin.
+Transceiver EEPROM accessing can be achieved by legacy sfputil.py plugin or new platform API. Xcvrd supports both methods. If platform API is not yet implemented on some vendor's device, it will automatically fall back on sfputil.py plugin.
 
-
-### 1.3 Transceiver change event and vendor platform API###
+### 1.3 Transceiver change event and vendor platform API ###
 
 #### 1.3.1 Transceiver change event ####
 
@@ -115,7 +112,7 @@ Currently 7 transceiver events are defined as below.
     status='5' High Temperature,
     status='6' Bad cable.
 
-However, multiple errors could exist at the same time. For example, a module can be unsupported cable and high temperature. The new transceiver event will be described in a bitmap. New transceiver definition below.
+However, multiple errors could exist at the same time. For example, a module can be unsupported cable and high temperature. The new transceiver event will be described in a bitmap.
 
     bit 32  : 0=SFP removed, 1=SFP inserted,
     bit 31  : 0=OK, 1=I2C bus stuck,
@@ -125,21 +122,38 @@ However, multiple errors could exist at the same time. For example, a module can
     bit 27  : 0=OK, 1=Bad cable.
     bit 1~26: reserved. Must be 0.
 
-Vendor can extend this bitmap with more errors. Xcvrd need parse the bitmap and set transceiver status table in DB accordingly. For example, if the transceiver event bit map is 0x7, the status field value should be "1" and the error field value should be "I2C bus stuck | Bad eeprom".
+    Define bit 32 as the least significant bit and bit 1 as the most significant bit.
+
+Vendor can extend this bitmap with more errors. However, some errors can be vendor specific, which means they won't occur on other vendors' platforms. The bitmap can grow rapidly and eventually run out of bits if all vendors insert vendor specific error codes to the bitmap.
+
+This can be resolved by dividing the bitmap into two parts: one for generic errors and the other for vendor specific errors. The bits 17 ~ 32 represent the generic errors and bits 1 ~ 16 represent the vendor specific errors.
+
+Xcvrd should parse the bitmap and set transceiver status table in database accordingly. The error descriptions is fetched in the following ways:
+
+- For generic errors, they will be translated from error bits by looking up a pre-defined dictionary as xcvrd has the necessary knowledge.
+- For vendor specific errors:
+  - If the platform API `get_change_event` returns a dict called `sfp_error`, the content of the dict will be taken as the error descriptions.
+  - Otherwise, the newly introduced platform API `get_error_description` will be called to fetch the descriptions.
+  - For both case, the error descriptions should reflect the vendor specific errors only. If there are multiple errors, the error descriptions should be joined by "|".
+
+Translating vendor specific error bits to descriptions is supported for platform API only. It is not supported for plugin because it needs to add new interfaces to plugin which needs all vendors to update their plugin.
+
+For example, if the transceiver event bit map is 0x7, the status field value should be "1" and the error field value should be "I2C bus stuck | Bad eeprom".
 
 #### 1.3.2 API to get Transceiver change event from platform ####
 
 Xcvrd need to be triggered by transceiver change event to refresh the transceiver info table.
 
-How to get this event is various on different platform, there is no common implementation available. 
+How to get this event is various on different platform. There is no common implementation available.
 
 ##### 1.3.2.1 Transceiver change event API in plugin #####
-In legacy sfputil.py plugin a new API was defined to wait for this event in class `SfpUtilBase`: 
+
+In legacy sfputil.py plugin a new API was defined to wait for this event in class `SfpUtilBase`:
 
     @abc.abstractmethod
     def get_transceiver_change_event(self, timeout=0):
         """
-	:param timeout: function will return success and a empty dict if no event in this period, default value is 0.
+        :param timeout: function will return success and a empty dict if no event in this period, default value is 0.
         :returns: Boolean, True if call successful, False if not; 
         dict for pysical port number and the SFP status, status '1' represent plug in, '0' represent plug out(eg. {'0': '1', '31':'0'})
         """
@@ -148,7 +162,10 @@ In legacy sfputil.py plugin a new API was defined to wait for this event in clas
 Each vendor need to implement this function in `SfpUtil` plugin.
 
 ##### 1.3.2.2 Transceiver change event API in new platform API #####
-In new platform API, similar change event API also defined, this API is not only for SFP, but also for other devices:
+
+In new platform API, similar change event API has also been defined and will be extended by adding `sfp_error` key. In case there is an error occurred, the platform API should reflect the error in the `sfp` key and can provide the error descriptions in `sfp_error` key.
+
+The API is defined as below:
 
     def get_change_event(self, timeout=0):
         """
@@ -169,30 +186,59 @@ In new platform API, similar change event API also defined, this API is not only
                         device_event,
                              status='1' represents device inserted,
                              status='0' represents device removed.
-                  Ex. {'fan':{'0':'0', '2':'1'}, 'sfp':{'11':'0'}}
-                      indicates that fan 0 has been removed, fan 2
-                      has been inserted and sfp 11 has been removed.
+                  Ex1. {'fan':{'0':'0', '2':'1'}, 'sfp':{'11':'0'}}
+                       indicates that fan 0 has been removed, fan 2
+                       has been inserted and sfp 11 has been removed.
+                  Ex2. {'sfp':{'11':'65537'}, 'sfp_error':{'11':'vendor specific error'}}
+                      indicates SFP 11 has been inserted with a vendor specific error represented by bit 17.
 
 ##### 1.3.2.3 Xcvrd wrapper for calling transceiver change event API #####
+
 Xcvrd uses a wrapper to call one of the above two APIs depends on the implementation status on a specific platform  to wait for the sfp plug in/out event, following example code showing how these APIs will be called:
 
     def _wrapper_get_transceiver_change_event(timeout):
-	    if platform_chassis is not None:
-	        try:
-	            status, events =  platform_chassis.get_change_event(timeout)
-	            sfp_events = events['sfp']
-	            return status, sfp_events
-	        except NotImplementedError:
-	            pass
-	    return platform_sfputil.get_transceiver_change_event(timeout)
-                 
-It's possible that when received the plug in/out event, the transceiver eeprom is not ready for reading, so need to give another try if first reading failed. 
+        if platform_chassis is not None:
+            try:
+                status, events =  platform_chassis.get_change_event(timeout)
+                sfp_events = events.get('sfp')
+                sfp_errors = events.get('sfp_error')
+                return status, sfp_events, sfp_errors
+            except NotImplementedError:
+                pass
+        return platform_sfputil.get_transceiver_change_event(timeout)
 
-#### 1.3.2 Transceiver plug in/out and error event implementation on Mellanox platform ####
+It's possible that when received the plug in/out event, the transceiver eeprom is not ready for reading, so need to give another try if first reading failed.
 
-On Mellanox platform the SFP events is exposed by mlnx SDK, the API will open a channel and listening to the SDK for the events. 
+#### 1.3.2 API to get error description of an SFP module ####
 
-During the API init phase(waiting for the channel with SDK created), if Xcvrd called this API and it will return SYSTEM_NOT_READY event. 
+As mentioned before, only platform API is supported for this API. Plugin isn't supported for it because it needs to extend the base class for the existing plugin, which needs all vendor to instantiate accordingly.
+
+##### 1.3.2.1 Platform API definition #####
+
+A new platform API in class SFP is required for fetching the error status of the SFP module.
+
+    def get_error_status(self)
+        """
+        Get error status of the SFP module
+        Returns:
+            string: represent the error
+        """
+
+##### 1.3.2.2 xcvrd wrapper #####
+
+    def _wrapper_get_sfp_error_description(physical_port):
+        if platform_chassis:
+            try:
+                return platform_chassis.get_sfp(physical_port).get_error_description()
+            except NotImplementedError:
+                pass
+        return None
+
+#### 1.3.3 Transceiver plug in/out and error event implementation on Mellanox platform ####
+
+On Mellanox platform the SFP events is exposed by mlnx SDK, the API will open a channel and listening to the SDK for the events.
+
+During the API init phase(waiting for the channel with SDK created), if Xcvrd called this API and it will return SYSTEM_NOT_READY event.
 
 If SDK failed due to some reason and channel closed, API will raised error(SYSTEM_FAIL) to Xcvrd.
 
@@ -202,9 +248,9 @@ Xcvrd will spawn a new process(sfp_state_update_task) to wait for the SFP plug i
 
 A thread will be started to periodically refresh the DOM sensor information.
 
-In the main loop of the Xcvrd task, it periodically check the integrity the DB, if some SFP info missing, will be added back. 
+In the main loop of the Xcvrd task, it periodically check the integrity the DB, if some SFP info missing, will be added back.
 
-Detailed flow as showed in below chart: 
+Detailed flow as showed in below chart:
 
 ![](https://github.com/keboliu/SONiC/blob/master/images/xcvrd-flow.svg)
 
@@ -237,20 +283,19 @@ In the process of handling SFP change event, a state machine is defined to handl
           NORMAL          SYSTEM NOT READY    INIT
           EXIT            -
 
-
 ![](https://github.com/keboliu/SONiC/blob/master/images/xcvrd_state_mahine.svg)
 
 #### 1.4.2 Transceiver error events handling procedure ####
 
-When error events(defined in section 1.3.1) received from some transceiver, the related interface TRANSCEIVER_STATUS table will be updated with the error code , and DOM information will be removed from the DB. 
+When error events(defined in section 1.3.1) received from some transceiver, the related interface TRANSCEIVER_STATUS table will be updated with the error code , and DOM information will be removed from the DB.
 
 Before the DOM update thread update the DOM info, it will check the Transceiver status table first, DOM info updating will be skipped if some port is in the error status. In the Xcvrd main task recovering missing interface info, same check will also be applied.
 
-Currently no explicit "error clear event" is defined, a plug in event will be considered as port recovered from error(on Mellanox platform it does send out a plug in event when recovered from error). 
+Currently no explicit "error clear event" is defined, a plug in event will be considered as port recovered from error(on Mellanox platform it does send out a plug in event when recovered from error).
 
 An explicit "error clear event" can be added if some vendor's platform supports this kind of event.
 
-On transceiver plug in or plug out events, the port error status will be cleared.     
+On transceiver plug in or plug out events, the port error status will be cleared.
 
 ## 2. SNMP Agent Change ##
 
@@ -271,7 +316,6 @@ MIB table entPhysicalTable from [Entity MIB(RFC2737)](https://tools.ietf.org/htm
 | 1.3.6.1.2.1.47.1.1.1.1.12.index | entPhysicalMfgName | Vendor Name in CLI or sfputil | FINISAR CORP |
 | 1.3.6.1.2.1.47.1.1.1.1.13.index | entPhysicalModelName | Vendor PN in CLI or sfputil| FCBN410QD3C02 |
 
-
 Another entPhySensorTable which is defined in [Entity Sensor MIB(RFC3433)](https://tools.ietf.org/html/rfc3433) need to be new added.
 
 | OID | SNMP counter | Where to get the info in Sonic. | Example: |
@@ -284,9 +328,103 @@ Another entPhySensorTable which is defined in [Entity Sensor MIB(RFC3433)](https
 | 1.3.6.1.2.1.99.1.1.1.4.index | entPhySensorValue | Same as above | 7998 |
 | 1.3.6.1.2.1.47.1.1.1.1.2.index | entPhysicalDescr | Show interfaces alias | DOM RX Power Sensor for DOM RX Power Sensor for Ethernet29/1 |
 
-
 More detailed information about new table and new OIDs are described in [Sensor and Transceiver Info Monitoring Requirement](https://github.com/Azure/SONiC/blob/master/doc/xrcvd/OIDsforSensorandTransciver.MD#transceiver-requirements-entity-mib).
 
+## 3. CLI change ##
 
+### 3.1 Add a command to fetch the error status ###
 
-      
+#### 3.1.1 sfputil extension ####
+
+The utility `sfputil` needs to be updated to extend to support fetching error status of SFP modules.
+The CLI is like this:
+
+    sfputil show error-status --fetch-from-hardware --port <port>
+
+The error status can be fetched for
+
+- A specific SFP module designed by --port argument
+- or all SPF modules if --port isn't provided
+
+By default, it will fetch the error status from `TRANSCEIVER_STATUS` in `STATE_DB`. It also supports fetching error status from low level component directly. In this case, it will call platform API `get_error_description` from the `pmon` docker.
+
+The error status of each SPF module should be:
+
+- `unplugged` if the module isn't plugged-in
+- `OK` if the module is plugged in without any error
+- Errors stored in `STATE_DB` or fetched from platform API.
+
+The output of the command is like this:
+
+    admin@sonic:~$ show interface transceiver error-status Ethernet8
+    Port       Error Status
+    ---------  ------------------------------------
+    Ethernet8  OK
+
+    admin@sonic:~$ show interface transceiver error-status
+    Port         Error Status
+    -----------  ----------------------------------------------
+    Ethernet0    OK
+    Ethernet4    OK
+    Ethernet8    OK
+    Ethernet12   OK
+    Ethernet16   OK
+    Ethernet20   OK
+    Ethernet24   OK
+    Ethernet28   OK
+    Ethernet32   OK
+    Ethernet36   OK
+    Ethernet40   OK
+    Ethernet44   Power budget exceeded
+    Ethernet48   OK
+    Ethernet52   OK
+    Ethernet56   OK
+    Ethernet60   OK
+    Ethernet64   OK
+    Ethernet68   OK
+    Ethernet72   OK
+    Ethernet76   OK
+    Ethernet80   OK
+    Ethernet84   OK
+    Ethernet88   OK
+    Ethernet92   OK
+    Ethernet96   OK
+    Ethernet100  OK
+    Ethernet104  OK
+    Ethernet108  OK
+    Ethernet112  OK
+    Ethernet116  OK
+    Ethernet120  OK
+    Ethernet124  OK
+    Ethernet128  OK
+    Ethernet132  OK
+    Ethernet136  OK
+    Ethernet140  OK
+    Ethernet144  OK
+    Ethernet148  OK
+    Ethernet152  OK
+    Ethernet156  OK
+    Ethernet160  OK
+    Ethernet164  OK
+    Ethernet168  Unplugged
+    Ethernet172  OK
+    Ethernet176  OK
+    Ethernet180  OK
+    Ethernet184  OK
+    Ethernet188  OK
+    Ethernet192  OK
+    Ethernet196  OK
+    Ethernet200  OK
+    Ethernet204  OK
+    Ethernet208  OK
+    Ethernet212  OK
+    Ethernet216  OK
+    Ethernet220  OK
+
+#### 3.1.2 show interface transceiver wrapper ####
+
+A wrapper command `show interface transceiver error-status` is also provided.
+
+    show interface transceiver error-status --fetch-from-hardware port
+
+The output is the same as that of `sfputil`.


### PR DESCRIPTION
- API get_change_event returns error description for vendor-specific errors
  xcvrd will call get_error_description if there is an error without a description
- The CLI fetch error status from STATE_DB by default

Signed-off-by: Stephen Sun <stephens@nvidia.com>