### PR TITLE
MPLS EXP to TC mapping HLD

### DIFF
--- a/doc/qos/mpls_exp_to_tc_map.md
+++ b/doc/qos/mpls_exp_to_tc_map.md
@@ -1,0 +1,131 @@
+# MPLS EXP to TC map
+
+## 1. Table of Content
+
+- [MPLS EXP to TC map](#mpls-exp-to-tc-map)
+  - [1. Table of Content](#1-table-of-content)
+  - [2. Revision](#2-revision)
+  - [3. Scope](#3-scope)
+  - [4. Definitions/Abbreviations](#4-definitionsabbreviations)
+  - [5. Overview](#5-overview)
+  - [6. Requirements](#6-requirements)
+  - [7. Architecture Design](#7-architecture-design)
+  - [8. High-Level Design](#8-high-level-design)
+    - [8.1. DB](#81-db)
+    - [8.2. sonic-swss-common](#82-sonic-swss-common)
+    - [8.3. sonic-swss](#83-sonic-swss)
+    - [8.4. sonic-utilities](#84-sonic-utilities)
+    - [8.5. Other implications](#85-other-implications)
+  - [9. SAI API](#9-sai-api)
+  - [10. Configuration and management](#10-configuration-and-management)
+    - [10.1. CLI/YANG model Enhancements](#101-cliyang-model-enhancements)
+    - [10.2. Config DB Enhancements](#102-config-db-enhancements)
+  - [11. Warmboot and Fastboot Design Impact](#11-warmboot-and-fastboot-design-impact)
+  - [12. Restrictions/Limitations](#12-restrictionslimitations)
+  - [13. Testing Requirements/Design](#13-testing-requirementsdesign)
+    - [13.1. Unit Test cases](#131-unit-test-cases)
+    - [13.2. System Test cases](#132-system-test-cases)
+  - [14. Open/Action items - if any](#14-openaction-items---if-any)
+
+## 2. Revision
+
+| Rev |     Date    |       Author            | Change Description                         |
+|:---:|:-----------:|:-----------------------:|--------------------------------------------|
+| 0.1 | 16/08/2021  |     Alexandru Banu      | Initial version                            |
+
+## 3. Scope
+
+This HLD extends SONiC to support MPLS EXP to TC mappings.
+
+## 4. Definitions/Abbreviations
+
+TC = Traffic Class
+QoS = Quality of Service
+
+## 5. Overview
+
+This new enhancement adds support to SONiC for MPLS EXP to TC map which allows QoS to work on MPLS packets.
+
+## 6. Requirements
+
+User can configure MPLS EXP to TC map at start-of-day via configuration file. CLI support will exist to offer the same amount of support as for DSCP to TC map.
+
+## 7. Architecture Design
+
+The overall SONiC architecture will not be changed and no new sub-modules will be introduced.
+
+## 8. High-Level Design
+
+### 8.1. DB
+
+The CONFIG DB will be updated to include a new "MPLS_EXP_TO_TC_MAP_TABLE" similar to the existing "DSCP_TO_TC_MAP_TABLE". This will have the following format:
+```
+### MPLS_EXP_TO_TC_MAP_TABLE
+    ; MPLS EXP to TC map
+    ;SAI mapping - qos_map object with SAI_QOS_MAP_ATTR_TYPE == sai_qos_map_type_t::SAI_QOS_MAP_MPLS_EXP_TO_TC
+    key        = "MPLS_EXP_TO_TC_MAP_TABLE:"name
+    ;field    value
+    mpls_exp_value = 1*DIGIT
+    tc_value       = 1*DIGIT
+
+    Example:
+    127.0.0.1:6379> hgetall "MPLS_EXP_TO_TC_MAP_TABLE:AZURE"
+     1) "3" ;mpls exp
+     2) "3" ;tc
+     3) "6"
+     4) "5"
+     5) "7"
+     6) "5"
+```
+
+### 8.2. sonic-swss-common
+
+sonic-swss-common's schema will be updated to include a CFG_MPLS_EXP_TO_TC_MAP_TABLE_NAME define for the new table name.
+
+### 8.3. sonic-swss
+
+sonic-swss's QoS orch will be updated to include a new handler for MPLS EXP to TC map, similar to the existing DSCP to TC map but with extra input validations, checking that the values are in the correct numeric range and that no MPLS EXP value is mapped to more than one TC value. Among debugging logs, appropriate error logs will be introduced to let the user know if they miss-configured a map.
+
+### 8.4. sonic-utilities
+
+sonic-utilities will be updated to offer the same amount of support for CLI commands that DSCP to TC map already provide.
+
+### 8.5. Other implications
+
+There are no other implications. SAI and sairedis already support for MPLS EXP to TC map. In terms of warm restart / fastboot / scalability / performance and so on, this should not represent an impact.
+
+## 9. SAI API
+
+MPLS EXP to TC map are already supported in SAI.
+
+## 10. Configuration and management
+
+### 10.1. CLI/YANG model Enhancements
+
+CLI config commands will be updated to include the same level of support for MPLS EXP to TC maps as for DSCP to TC maps. Namely, `config reload` and `config clear` will be updated to include the new mapping table as well.
+
+### 10.2. Config DB Enhancements
+
+The relevant changes have been described in HLD's DB sub-section.
+
+## 11. Warmboot and Fastboot Design Impact
+
+Not impacted by the changes.
+
+## 12. Restrictions/Limitations
+
+User can't configure MPLS EXP to TC map via CLI (only via reload command).
+
+## 13. Testing Requirements/Design
+
+### 13.1. Unit Test cases
+
+The QoS UTs present in sonic-swss will be extended to accommodate the new MPLS EXP to TC map. These will largely follow the DSCP to TC map example but will add input validation checks as well. The new code will have full code coverage as far as the UT framework allows it.
+
+### 13.2. System Test cases
+
+No system test cases will be added.
+
+## 14. Open/Action items - if any
+
+N/A

--- a/doc/qos/mpls_tc_to_tc_map.md
+++ b/doc/qos/mpls_tc_to_tc_map.md
@@ -1,8 +1,8 @@
-# MPLS EXP to TC map
+# MPLS TC to TC map
 
 ## 1. Table of Content
 
-- [MPLS EXP to TC map](#mpls-exp-to-tc-map)
+- [MPLS TC to TC map](#mpls-tc-to-tc-map)
   - [1. Table of Content](#1-table-of-content)
   - [2. Revision](#2-revision)
   - [3. Scope](#3-scope)
@@ -32,10 +32,11 @@
 | Rev |     Date    |       Author            | Change Description                         |
 |:---:|:-----------:|:-----------------------:|--------------------------------------------|
 | 0.1 | 16/08/2021  |     Alexandru Banu      | Initial version                            |
+| 0.2 | 21/09/2021  |     Alexandru Banu      | Renamed MPLS EXP to MPLS TC per RFC 5462   |
 
 ## 3. Scope
 
-This HLD extends SONiC to support MPLS EXP to TC mappings.
+This HLD extends SONiC to support MPLS TC to TC mappings.
 
 ## 4. Definitions/Abbreviations
 
@@ -44,11 +45,11 @@ QoS = Quality of Service
 
 ## 5. Overview
 
-This new enhancement adds support to SONiC for MPLS EXP to TC map which allows QoS to work on MPLS packets.
+This new enhancement adds support to SONiC for MPLS TC to TC map which allows QoS to work on MPLS packets.
 
 ## 6. Requirements
 
-User can configure MPLS EXP to TC map at start-of-day via configuration file. CLI support will exist to offer the same amount of support as for DSCP to TC map.
+User can configure MPLS TC to TC map at start-of-day via configuration file. CLI support will exist to offer the same amount of support as for DSCP to TC map.
 
 ## 7. Architecture Design
 
@@ -58,19 +59,19 @@ The overall SONiC architecture will not be changed and no new sub-modules will b
 
 ### 8.1. DB
 
-The CONFIG DB will be updated to include a new "MPLS_EXP_TO_TC_MAP_TABLE" similar to the existing "DSCP_TO_TC_MAP_TABLE". This will have the following format:
+The CONFIG DB will be updated to include a new "MPLS_TC_TO_TC_MAP_TABLE" similar to the existing "DSCP_TO_TC_MAP_TABLE". This will have the following format:
 ```
-### MPLS_EXP_TO_TC_MAP_TABLE
-    ; MPLS EXP to TC map
+### MPLS_TC_TO_TC_MAP_TABLE
+    ; MPLS TC to TC map
     ;SAI mapping - qos_map object with SAI_QOS_MAP_ATTR_TYPE == sai_qos_map_type_t::SAI_QOS_MAP_MPLS_EXP_TO_TC
-    key        = "MPLS_EXP_TO_TC_MAP_TABLE:"name
+    key        = "MPLS_TC_TO_TC_MAP_TABLE:"name
     ;field    value
-    mpls_exp_value = 1*DIGIT
-    tc_value       = 1*DIGIT
+    mpls_tc_value = 1*DIGIT
+    tc_value      = 1*DIGIT
 
     Example:
-    127.0.0.1:6379> hgetall "MPLS_EXP_TO_TC_MAP_TABLE:AZURE"
-     1) "3" ;mpls exp
+    127.0.0.1:6379> hgetall "MPLS_TC_TO_TC_MAP_TABLE:AZURE"
+     1) "3" ;mpls tc
      2) "3" ;tc
      3) "6"
      4) "5"
@@ -80,11 +81,11 @@ The CONFIG DB will be updated to include a new "MPLS_EXP_TO_TC_MAP_TABLE" simila
 
 ### 8.2. sonic-swss-common
 
-sonic-swss-common's schema will be updated to include a CFG_MPLS_EXP_TO_TC_MAP_TABLE_NAME define for the new table name.
+sonic-swss-common's schema will be updated to include a CFG_MPLS_TC_TO_TC_MAP_TABLE_NAME define for the new table name.
 
 ### 8.3. sonic-swss
 
-sonic-swss's QoS orch will be updated to include a new handler for MPLS EXP to TC map, similar to the existing DSCP to TC map but with extra input validations, checking that the values are in the correct numeric range and that no MPLS EXP value is mapped to more than one TC value. Among debugging logs, appropriate error logs will be introduced to let the user know if they miss-configured a map.
+sonic-swss's QoS orch will be updated to include a new handler for MPLS TC to TC map, similar to the existing DSCP to TC map but with extra input validations, checking that the values are in the correct numeric range and that no MPLS TC value is mapped to more than one TC value. Among debugging logs, appropriate error logs will be introduced to let the user know if they miss-configured a map.
 
 ### 8.4. sonic-utilities
 
@@ -92,17 +93,17 @@ sonic-utilities will be updated to offer the same amount of support for CLI comm
 
 ### 8.5. Other implications
 
-There are no other implications. SAI and sairedis already support for MPLS EXP to TC map. In terms of warm restart / fastboot / scalability / performance and so on, this should not represent an impact.
+There are no other implications. SAI and sairedis already support for MPLS TC to TC map. In terms of warm restart / fastboot / scalability / performance and so on, this should not represent an impact.
 
 ## 9. SAI API
 
-MPLS EXP to TC map are already supported in SAI.
+MPLS TC to TC map are already supported in SAI.
 
 ## 10. Configuration and management
 
 ### 10.1. CLI/YANG model Enhancements
 
-CLI config commands will be updated to include the same level of support for MPLS EXP to TC maps as for DSCP to TC maps. Namely, `config reload` and `config clear` will be updated to include the new mapping table as well.
+CLI config commands will be updated to include the same level of support for MPLS TC to TC maps as for DSCP to TC maps. Namely, `config reload` and `config clear` will be updated to include the new mapping table as well.
 
 ### 10.2. Config DB Enhancements
 
@@ -114,13 +115,13 @@ Not impacted by the changes.
 
 ## 12. Restrictions/Limitations
 
-User can't configure MPLS EXP to TC map via CLI (only via reload command).
+User can't configure MPLS TC to TC map via CLI (only via reload command).
 
 ## 13. Testing Requirements/Design
 
 ### 13.1. Unit Test cases
 
-The QoS UTs present in sonic-swss will be extended to accommodate the new MPLS EXP to TC map. These will largely follow the DSCP to TC map example but will add input validation checks as well. The new code will have full code coverage as far as the UT framework allows it.
+The QoS UTs present in sonic-swss will be extended to accommodate the new MPLS TC to TC map. These will largely follow the DSCP to TC map example but will add input validation checks as well. The new code will have full code coverage as far as the UT framework allows it.
 
 ### 13.2. System Test cases
 


### PR DESCRIPTION
This HLD presents the design for adding the MPLS EXP to TC QoS mapping, along the existing DSCP to TC mapping.

Code PRs:
swss-common: https://github.com/Azure/sonic-swss-common/pull/537
swss: https://github.com/Azure/sonic-swss/pull/1954
utilites: https://github.com/Azure/sonic-utilities/pull/1875