### PR TITLE
[ZTP] Fixed typo in path '/host/ztp/ztp_local_data.json'

### DIFF
--- a/doc/ztp/ztp.md
+++ b/doc/ztp/ztp.md
@@ -715,7 +715,7 @@ If user does not provide both DHCP option 67 or DHCP option 239, ZTP service con
 
 Following is the order in which DHCP options are processed:
 
-1. The ZTP JSON file specified in pre-defined location as part of the image Local file on disk */host/ztp/ztp_local_data.json*.
+1. The ZTP JSON file specified in pre-defined location as part of the image Local file on disk */host/ztp/ztp_data_local.json*.
 2. ZTP JSON URL specified via DHCP Option-67
 3. ZTP JSON URL constructed using  DHCP Option-66 TFTP server name, DHCP Option-67 file path on TFTP server
 4. ZTP JSON URL specified via DHCPv6 Option-59


### PR DESCRIPTION
Fixed typo in pre-defined location to ZTP JSON file.
`ztp_local_data.json` is not valid name for ZTP JSON file, and will not be read by the ZTP service.
[Link](https://github.com/Azure/sonic-ztp/blob/879d7bdd460987260d73866ba65f8d547b845c70/src/usr/lib/python3/dist-packages/ztp/defaults.py#L66) to Azure/sonic-ztp where `/host/ztp/ztp_data_local.json` are pre-defined file name.