### PR TITLE
Updated a typo error

### DIFF
--- a/Supported-Devices-and-Platforms.html
+++ b/Supported-Devices-and-Platforms.html
@@ -237,7 +237,7 @@ function Port_Config() {
 </tr>
 </tbody>
 </table>
-<h2><p style="text-align: left; font-family: Verdana, sans-serif; color: #2E86C1; font-size: 20px">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Following1 is the list of platforms that supports SONiC.</p></h2>
+<h2><p style="text-align: left; font-family: Verdana, sans-serif; color: #2E86C1; font-size: 20px">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Following is the list of platforms that supports SONiC.</p></h2>
 <br>
 
 <table id="myTable" style="width: 70%; background-color: #ffffff; font-family: Verdana, sans-serif;" align="center">


### PR DESCRIPTION
Updated a typo error for the sentence "Following1 is the list of platforms that supports SONiC." as Following is the list of platforms that supports SONiC.