### PR TITLE
Updating 202111_Release_notes with SAI 1.9.1 Release_notes link

### DIFF
--- a/doc/SONiC_202111_Release_Notes.md
+++ b/doc/SONiC_202111_Release_Notes.md
@@ -214,7 +214,7 @@ Refer [HLD document](https://github.com/Azure/SONiC/blob/master/doc/Query_Stats_
 
 # SAI APIs
 
-Please find the list of API's classified along the newly added SAI features. For further details on SAI API please refer [SAI_1.9.1 Release Notes](https://github.com/opencomputeproject/SAI/blob/master/doc/SAI_1.9.1%20Release%20notes.md)
+Please find the list of API's classified along the newly added SAI features. For further details on SAI API please refer [SAI_1.9.1 Release Notes](https://github.com/opencomputeproject/SAI/blob/master/doc/SAI_1.9.1_ReleaseNotes.md)
 
 
 # Contributors 


### PR DESCRIPTION
This PR is to update the SAI 1.9.1 release notes link to  202111 Release notes. Request to kindly approve