### PR TITLE
Update `DSCP_TO_TC_MAP` and `TC_TO_DSCP_MAP` for 33

### DIFF
--- a/doc/qos/tunnel_dscp_remapping.md
+++ b/doc/qos/tunnel_dscp_remapping.md
@@ -105,7 +105,7 @@ Before remapping to queue 2 and 6, both queues are required to be cleared. Hence
             "30": "1",
             "31": "1",
             "32": "1",
-            "33": "1",
+            "33": "2", // Original map "33" : "1" 
             "34": "1",
             "35": "1",
             "36": "1",
@@ -180,7 +180,7 @@ Before remapping to queue 2 and 6, both queues are required to be cleared. Hence
         "AZURE_TUNNEL": {
             "0": "8",
             "1": "0",
-            "2": "0",
+            "2": "33",
             "3": "2",
             "4": "6",
             "5": "46",


### PR DESCRIPTION
This PR is to update the HLD for tunnel DSCP remapping.

There are certain DCSP values that need to be preserved. One of them is dscp 33

So, DSCP `33` is mapped to TC `2` on ToR, and the outlayer DSCP value of encapped packet for TC `2` is rewriten to `33`. 

Signed-off-by: bingwang <bingwang@microsoft.com>