### PR TITLE
Expand docker manifest capabilities to include network and ports configuration

### DIFF
--- a/doc/sonic-application-extension/sonic-application-extension-guide.md
+++ b/doc/sonic-application-extension/sonic-application-extension-guide.md
@@ -200,6 +200,8 @@ The value should contain a JSON serialized as a string.
 | /container | object | no        | Container related properties.                                                                    |
 | /container/privileged         | string          | no        | Start the container in privileged mode. Later versions of manifest might extend container properties to include docker capabilities instead of privileged mode. Defaults to False. |
 | /container/volumes            | list of strings | no        | List of mounts for a container. The same syntax used for '-v' parameter for "docker run".<p>Example: "\<src\>:\<dest\>:\<options\>". Defaults to [].                               |
+| /container/network           | string           | no        | Define the container network type. e.g.: 'bridge', 'host', etc.
+| /container/ports             | list of strings  | no        | List of ports to publish for the docker. e.g.: ["8080:8080", "22:22"]
 | /container/mounts             | list of objects | no        | List of mounts for a container. Defaults to [].                                                                                                                                    |
 | /container/mounts/[id]/source | string          | yes       | Source for mount                                                                                                                                                                   |
 | /container/mounts/[id]/target | string          | yes       | Target for mount                                                                                                                                                                   |


### PR DESCRIPTION
Adding documentation regarding the network and ports configurations for docker manifest


| Submodule | PR Title | Status |
| ---| --- | --- |
| sonic-buildimage | [Adjusting docker creation to include ports forwarding and docker network type](https://github.com/sonic-net/sonic-buildimage/pull/16248) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-buildimage/16248) |
| sonic-utilities | [Expanding the manifest capabilities](https://github.com/sonic-net/sonic-utilities/pull/2952) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-utilities/2952) |