### PR TITLE
[COPP:Yang-changes] Fix for config replace issues seen with COPP configurations

### DIFF
--- a/doc/copp/CoPP Config and Management.md
+++ b/doc/copp/CoPP Config and Management.md
@@ -165,7 +165,8 @@ The following flow captures CoPP manager functionality.
             "mode":"sr_tcm",
             "cir":"600",
             "cbs":"600",
-            "red_action":"drop"
+            "red_action":"drop",
+            "trap_action":"trap"
         },
 
         "COPP_GROUP|queue4_group1": {


### PR DESCRIPTION
==> Issue: 
       config replace/yang-validation fails for COPP configurations.

==> Root cause:
• COPP's device initial config copp_cfg.json has missing yang mandatory leaf "trap_action" for "default" COPP_GROUP.
• "genetlink_name" & "genetlink_mcgrp_name" nodes are not added in sonic-copp.yang, which are used for "queue2_group1" in copp_cfg.json

==> Fix:
• In copp_cfg.json, mandatory leaf "trap_action" is added for "default" COPP_GROUP.

"COPP_GROUP": {
"default": {

"trap_action":"trap", <<< this node needs to be added
"queue": "0",
"meter_type":"packets",
• "genetlink_name" and "genetlink_mcgrp_name" leaves are added in sonic-copp.yang.

• DB Migration script is updated to upgrade the DB config automatically.

==> Tests :
Config replace ->
i. Config load copp_cfg.json
ii. Config save
iii. Config replace -> Ensure no error seen

Upgrade ->
i. Save config in build without the fix
ii. upgrade to build with changes and ensure configurations are reflected in new config_db.json

==> PRs :
Sonic-buildimage : https://github.com/sonic-net/sonic-buildimage/pull/19817
Sonic-utilities : https://github.com/sonic-net/sonic-utilities/pull/3473
SONiC (docs) :  https://github.com/sonic-net/SONiC/pull/1773

Signed-off-by: Anukul Verma <anukverm@cisco.com>