### PR TITLE
[SNMP:Contact] Fix for config replace failure with SNMP Contact issue

### DIFF
--- a/doc/snmp/snmp-configdb-migration-hld.md
+++ b/doc/snmp/snmp-configdb-migration-hld.md
@@ -36,8 +36,8 @@ admin@switch1:~$ redis-cli -n 4 hgetall "SNMP|LOCATION"
 2) "Emerald City"
 
 admin@switch1:~$ redis-cli -n 4 hgetall "SNMP|CONTACT"
-1) "joe"
-2) "joe@contoso.com"
+1) "Contact"
+2) "joe joe@contoso.com"
 ```
 
 # SNMP_COMMUNITY Table
@@ -127,12 +127,12 @@ Options:
 admin@switch1:~$
 
 admin@switch1:~$ show run snmp contact
-Contact    Contact Email
----------  -----------------
-Joe        joe@contoso.com
+Contact
+---------
+joe joe@contoso.com
 admin@switch1:~$
 admin@switch1:~$ show run snmp contact --json
-{'joe': 'joe@contoso.com'}
+{'Contact': 'joe joe@contoso.com'}
 admin@switch1:~$
 ```
 
@@ -246,28 +246,28 @@ Options:
   -h, -?, --help  Show this message and exit.
 
 Commands:
-  add     Add snmp contact name and email
-  del     Delete snmp contact name and email
+  add     Add snmp contact
+  del     Delete snmp contact
   modify  Modify snmp contact
 admin@switch1:~$
 admin@switch1:~$ sudo config snmp contact add -h
-Usage: config snmp contact add [OPTIONS] <contact_name> <contact_email>
+Usage: config snmp contact add [OPTIONS] <contact>
 
-  Add snmp contact name and email
+  Add snmp contact
 
 Options:
   -?, -h, --help  Show this message and exit.
 admin@switch1:~$
 admin@switch1:~$ sudo config snmp contact del -h
-Usage: config snmp contact del [OPTIONS] <contact_name>
+Usage: config snmp contact del [OPTIONS] <contact>
 
-  Delete snmp contact name and email
+  Delete snmp contact
 
 Options:
   -h, -?, --help  Show this message and exit.
 admin@switch1:~$
 admin@switch1:~$ sudo config snmp contact modify -h
-Usage: config snmp contact modify [OPTIONS] <contact> <contact email>
+Usage: config snmp contact modify [OPTIONS] <contact>
 
   Modify snmp contact
 

--- a/doc/snmp/snmp-schema-addition.md
+++ b/doc/snmp/snmp-schema-addition.md
@@ -33,7 +33,7 @@ In the end this is used to produce */etc/snmp/snmpd.conf*.
          "Location":"<SNMP_LOCATION_STRING>"
       },
       "CONTACT":{
-         "<CONTACT_NAME>":"<SNMP_CONTACT_STRING>"
+         "Contact":"<SNMP_CONTACT_STRING>"
       }
    }
 }


### PR DESCRIPTION
==> Issue:
• Config replace/yang-validation fails for SNMP contact configuration.
• In SNMP contact CLI, email field is mandatory
Related to https://github.com/sonic-net/sonic-buildimage/issues/12620

==> Root Cause:
• sonic-snmp.yang defines leaf Contact, but sonic-utilities (CLI backend) writes to ConfigDB with key {contact_name}. So YANG validation fails when the key is {contact_name} and not the string "Contact"
• CLI current implementation is expecting two mandatory arguments

==> Fix:
• sonic-utilities (CLI backend) code is updated to use Yang leaf name "Contact" string as key and user passed input as "value"
• CLI implementation (sonic-utilities) is changed to expect only a single string, where user can pass any string of choice (name, email, phone, address or combination of these). Accordingly, "show" CLIs will display only "contact" instead of "name" & "email"
* Migration script is updated to take care of config_db migration

Tests:
* Test CLIs manually
* Test config replace
* Test config migration

PRs :
sonic-buildimage - https://github.com/sonic-net/sonic-buildimage/pull/19834
sonic-utilities -  https://github.com/sonic-net/sonic-utilities/pull/3476
SONiC (docs) -  https://github.com/sonic-net/SONiC/pull/1774

Signed-off-by: Anukul Verma <anukverm@cisco.com>
