### PR TITLE
Linux VRF Route Lookup Fallback Control HLD

### DIFF
--- a/doc/vrf/linux-vrf-route-lookup-fallback-control-hld.md
+++ b/doc/vrf/linux-vrf-route-lookup-fallback-control-hld.md
@@ -1,4 +1,4 @@
-# No Default VRF Route Fallback
+# Linux VRF Route Lookup Fallback Control
 
 ## Table of Contents
 
@@ -26,10 +26,11 @@
 | 3.0 | 2026-07-02 | Sudharsan Rajagopalan | Clarified the kernel-only scope and CONFIG_DB-only management; removed the CLI design |
 | 3.1 | 2026-07-02 | Sudharsan Rajagopalan | Clarified the Linux and prior downstream defaults, the intentional upstream default change, and upgrade mapping |
 | 3.2 | 2026-07-02 | Sudharsan Rajagopalan | Clarified namespace-local multi-ASIC persistence, applicable VRFs, and rollback ordering |
+| 3.3 | 2026-07-02 | Sudharsan Rajagopalan | Renamed the feature to Linux VRF Route Lookup Fallback Control |
 
 ## 2. Scope
 
-This HLD changes only Linux VRF route lookup for traffic processed by the host kernel, including VRF-bound locally originated traffic and packets forwarded in software. It does not add or modify hardware routes, SAI objects, or ASIC forwarding behavior.
+Linux VRF Route Lookup Fallback Control changes only Linux VRF route lookup for traffic processed by the host kernel, including VRF-bound locally originated traffic and packets forwarded in software. It does not add or modify hardware routes, SAI objects, or ASIC forwarding behavior.
 
 - By default, `vrfmgrd` disables legacy Linux routing-policy database (RPDB) fall-through by installing managed IPv4 and IPv6 unreachable default routes in each applicable non-default Linux VRF table.
 - A temporary global CONFIG_DB setting can remove those routes, restoring fallback in the Linux kernel route-lookup path, including VRF-bound local output and software-forwarded packets, by permitting RPDB lookup to continue to later rules and tables.

--- a/doc/vrf/no-default-vrf-route-fallback-hld.md
+++ b/doc/vrf/no-default-vrf-route-fallback-hld.md
@@ -1,0 +1,166 @@
+= High-Level Design Document - No Default VRF Route Fallback
+:toc: left
+:toclevels: 4
+:sectnums:
+
+Revision History
+| Rev | Date       | Author      | Description                                |
+|-----|------------|-------------|--------------------------------------------|
+| 1.0 | <Date>     | <Your Name> | Initial draft for VRF route fallback control |
+
+== 1. Introduction
+In current implementations of SONiC, the route lookup behavior can fall back to other VRFs (Virtual Routing and Forwarding) when a route is not found in a non-default VRF. This can lead to unintended consequences.
+
+This document outlines a proposed solution to enhance SONiC's multi-VRF capabilities by providing a configurable mechanism to disable this fallback behavior. By introducing unreachable default routes in Linux VRF tables, the solution eliminates the need for kernel changes while allowing flexible, per-VRF and global configuration of fallback behavior.
+
+== 2. Problem Description
+When a route is not found in a specific non-default VRF, the Linux kernel, by default, performs a fallback route lookup in other VRFs in the order found in IP table rules. This behavior may not always align with network operators' intent, potentially leading to security risks or routing inaccuracies. A mechanism to disable this fallback—both globally and on a per-VRF basis—is required to provide more control and flexibility.
+
+== 3. Feature Design
+
+=== 3.1 High-Level Design
+The proposed solution adds a configurable mechanism to disable fallback to other VRFs. This is achieved by introducing unreachable default routes in the corresponding Linux VRF tables. The solution does not require kernel-level changes and instead leverages SONiC's existing infrastructure, including `CONFIG_DB`, CLI utilities, and the VRF Manager Daemon (`vrfmgrd`).
+
+*Key Features:*
+* *Global and Per-VRF Configuration:* Operators can disable fallback globally or override it on a per-VRF basis.
+* *Retain Default Behavior:* The system defaults to the current behavior (fallback allowed) unless explicitly configured otherwise.
+* *Support for IPv4 and IPv6:* The solution ensures that both IPv4 and IPv6 routes are handled appropriately.
+
+*Behavior Precedence:*
+. Default behavior allows fallback unless explicitly disabled (same as today).
+. Per-VRF configuration overrides the global setting.
+
+=== 3.2 DB Schema Changes
+The following tables will be added to `CONFIG_DB` to manage the fallback configuration.
+
+==== 3.2.1 Global Setting
+The `VRF_ROUTE_FALLBACK_GLOBAL` table will store the global fallback status for IPv4 and IPv6.
+
+[source,json]
+----
+"VRF_ROUTE_FALLBACK_GLOBAL|ipv4": {
+    "status": "enabled"
+},
+"VRF_ROUTE_FALLBACK_GLOBAL|ipv6": {
+    "status": "disabled"
+}
+----
+
+==== 3.2.2 Per-VRF Setting
+The `VRF` table will be extended with an optional attribute to override the global setting on a per-VRF basis.
+
+[source,json]
+----
+"VRF|VrfRed": {
+    "fallback": "enabled"
+},
+"VRF|VrfBlue": {
+    "fallback_v6": "disabled"
+}
+----
+
+=== 3.3 CLI Enhancements (sonic-utilities)
+
+==== 3.3.1 Configuration Commands
+New CLI commands will be introduced to manage the global and per-VRF fallback settings.
+
+.Usage Help
+[source,bash]
+----
+user@sonic# config vrf route-fallback -h
+Usage: config vrf route-fallback [OPTIONS] [ipv4|ipv6] [enable|disable]
+  Configure route fallback globally or for a specific VRF
+
+Options:
+  -v, --vrf-name TEXT  VRF name
+  -d, --delete         Delete override entry
+  -?, -h, --help       Show this message and exit.
+----
+
+.Global Fallback Configuration Examples
+[source,bash]
+----
+config vrf route-fallback ipv4 disable
+config vrf route-fallback ipv6 enable
+----
+
+.Per-VRF Fallback Configuration Examples
+[source,bash]
+----
+config vrf route-fallback ipv4 disable -v VrfRed
+config vrf route-fallback ipv6 enable -v VrfBlue
+----
+
+==== 3.3.2 Show Command
+A new `show` command will display the current fallback configuration.
+
+.Sample Output
+[literal]
+----
+user@sonic# show vrf-route-fallback
+MGMT_VRF_CONFIG is not present.
+
+Protocol: ipv4
+Global Fallback: Enabled
+
+VRF Name    Fallback (Override)
+----------  ---------------------
+VrfRed      Enabled
+
+Protocol: ipv6
+Global Fallback: Enabled
+
+VRF Name    Fallback (Override)
+----------  ---------------------
+VrfRed      Enabled
+----
+
+==== 3.3.3 CLI Backend Processing
+The CLI backend will be implemented with the following logic:
+*   Implement CLI hooks to update `CONFIG_DB` with global and per-VRF fallback settings.
+*   Validate VRF existence before processing per-VRF requests.
+*   Use `swsscommon` or `sonic-db-cli` for database interaction.
+
+=== 3.4 VRF Manager (vrfmgrd) Changes
+The `vrfmgrd` daemon in `sonic-swss` will be responsible for applying the configuration.
+
+*Responsibilities:*
+* *Monitor:* `VRF_ROUTE_FALLBACK_GLOBAL` and `VRF` tables in `CONFIG_DB`.
+* *Apply Logic:* Use the per-VRF value if defined; otherwise, use the global setting.
+* *Add Unreachable Routes:* When fallback is disabled for a VRF, add an unreachable default route.
+** `ip route add unreachable default metric 4278198272 vrf <VRF_NAME>`
+** `ip -6 route add unreachable default metric 4278198272 vrf <VRF_NAME>`
+* *Remove Unreachable Routes:* When fallback is enabled, remove the unreachable default route.
+** `ip route del unreachable default vrf <VRF_NAME>`
+** `ip -6 route del unreachable default vrf <VRF_NAME>`
+
+NOTE: If a real default route (e.g., `0.0.0.0/0` or `::/0`) is configured in the VRF with a lower metric, it will take precedence over the unreachable default. The Linux kernel selects routes based on metric and prefix specificity, ensuring correct behavior.
+
+=== 3.5 SAI and Hardware Impact
+Unreachable routes must not be programmed into the ASIC hardware to avoid unnecessary table usage.
+
+*Work Items:*
+*   Update `vrfmgrd` or related components to tag unreachable routes as software-only.
+*   Extend route orchestration logic to detect `unreachable` next-hop types and avoid programming them via SAI.
+*   Ensure FRR or Zebra does not install or redistribute these unreachable routes into BGP or other routing protocols.
+
+NOTE: The unreachable default route primarily affects software-forwarded packets—such as control-plane traffic, BGP sessions, and management traffic—by stopping fallback to other VRFs within the Linux kernel routing logic. This route is not intended to be used in hardware and has no impact on dataplane traffic handled by the ASIC. This allows operators to retain kernel-level route control without polluting the hardware FIB.
+
+=== 3.6 Config Reload and Persistence
+The feature must support configuration persistence across reboots and `config reload` operations.
+*   Fallback settings and routes must persist.
+*   Route reconciliation logic will be implemented at daemon startup to ensure the kernel state matches the configuration.
+
+== 4. Testing Plan
+
+=== 4.1 Unit Tests
+*   CLI command behavior and validation (e.g., correct arguments, VRF existence).
+*   `CONFIG_DB` schema integrity and backend processing logic.
+
+=== 4.2 Integration Tests
+*   Verify VRF route fallback behavior is disabled when the unreachable route is present.
+*   Verify per-VRF settings correctly override the global setting.
+*   Verify the global setting is applied correctly to all VRFs without an override.
+*   Test IPv4 and IPv6 functionality independently.
+*   Confirm persistence after `config reload` and system reboot.
+*   Verify that unreachable routes are not programmed into the ASIC FIB.

--- a/doc/vrf/no-default-vrf-route-fallback-hld.md
+++ b/doc/vrf/no-default-vrf-route-fallback-hld.md
@@ -1,52 +1,131 @@
-# High-Level Design Document - No Default VRF Route Fallback
+# No Default VRF Route Fallback
 
-## Table of Contents
-- [1. Introduction](#1-introduction)
-- [2. Problem Description](#2-problem-description)
-- [3. Feature Design](#3-feature-design)
-  - [3.1 High-Level Design](#31-high-level-design)
-  - [3.2 DB Schema Changes](#32-db-schema-changes)
-  - [3.3 CLI Enhancements (sonic-utilities)](#33-cli-enhancements-sonic-utilities)
-  - [3.4 VRF Manager (vrfmgrd) Changes](#34-vrf-manager-vrfmgrd-changes)
-  - [3.5 SAI and Hardware Impact](#35-sai-and-hardware-impact)
-  - [3.6 Config Reload and Persistence](#36-config-reload-and-persistence)
-- [4. Testing Plan](#4-testing-plan)
-  - [4.1 Unit Tests](#41-unit-tests)
-  - [4.2 Integration Tests](#42-integration-tests)
+## Table of Content
 
-## Revision History
+### 1. Revision
+### 2. Scope
+### 3. Definitions/Abbreviations
+### 4. Overview
+### 5. Requirements
+### 6. Architecture Design
+### 7. High-Level Design
+### 8. SAI API
+### 9. Configuration and Management
+### 10. Warmboot and Fastboot Design Impact
+### 11. Memory Consumption
+### 12. Restrictions/Limitations
+### 13. Testing Requirements/Design
+### 14. Open/Action Items
+
+## 1. Revision
+
 | Rev | Date       | Author      | Description                                |
 |-----|------------|-------------|--------------------------------------------|
 | 1.0 | <Date>     | <Your Name> | Initial draft for VRF route fallback control |
 
-## 1. Introduction
-In current implementations of SONiC, the route lookup behavior can fall back to other VRFs (Virtual Routing and Forwarding) when a route is not found in a non-default VRF. This can lead to unintended consequences.
+## 2. Scope
+
+This high-level design document covers the implementation of a configurable mechanism to disable VRF (Virtual Routing and Forwarding) route fallback behavior in SONiC. The scope includes:
+
+- Global and per-VRF configuration of route fallback behavior
+- CONFIG_DB schema changes for fallback configuration
+- CLI enhancements for configuration and monitoring
+- VRF Manager daemon modifications
+- Support for both IPv4 and IPv6 protocols
+- Configuration persistence and migration handling
+
+## 3. Definitions/Abbreviations
+
+| Term | Definition |
+|------|------------|
+| VRF | Virtual Routing and Forwarding |
+| FIB | Forwarding Information Base |
+| SAI | Switch Abstraction Interface |
+| ASIC | Application-Specific Integrated Circuit |
+| BGP | Border Gateway Protocol |
+| FRR | Free Range Routing |
+
+## 4. Overview
+
+In current implementations of SONiC, the route lookup behavior can fall back to other VRFs when a route is not found in a non-default VRF. This can lead to unintended consequences and security risks.
 
 This document outlines a proposed solution to enhance SONiC's multi-VRF capabilities by providing a configurable mechanism to disable this fallback behavior. By introducing unreachable default routes in Linux VRF tables, the solution eliminates the need for kernel changes while allowing flexible, per-VRF and global configuration of fallback behavior.
 
-## 2. Problem Description
-When a route is not found in a specific non-default VRF, the Linux kernel, by default, performs a fallback route lookup in other VRFs in the order found in IP table rules. This behavior may not always align with network operators' intent, potentially leading to security risks or routing inaccuracies. A mechanism to disable this fallback—both globally and on a per-VRF basis—is required to provide more control and flexibility.
+## 5. Requirements
 
-## 3. Feature Design
+### 5.1. Functional Requirements
 
-### 3.1 High-Level Design
-The proposed solution adds a configurable mechanism to disable fallback to other VRFs. This is achieved by introducing unreachable default routes in the corresponding Linux VRF tables. The solution does not require kernel-level changes and instead leverages SONiC's existing infrastructure, including `CONFIG_DB`, CLI utilities, and the VRF Manager Daemon (`vrfmgrd`).
+- **FR-1**: Support global configuration to disable VRF route fallback for IPv4 and IPv6
+- **FR-2**: Support per-VRF override of global fallback configuration
+- **FR-3**: Maintain current fallback behavior as default (backward compatibility)
+- **FR-4**: Support both IPv4 and IPv6 route fallback control independently
+- **FR-5**: Persist configuration across reboots and config reload operations
+- **FR-6**: Provide CLI commands for configuration and monitoring
+- **FR-7**: Support seamless upgrade/downgrade scenarios
 
-**Key Features:**
-* **Global and Per-VRF Configuration:** Operators can disable fallback globally or override it on a per-VRF basis.
-* **Retain Default Behavior:** The system defaults to the current behavior (fallback allowed) unless explicitly configured otherwise.
-* **Support for IPv4 and IPv6:** The solution ensures that both IPv4 and IPv6 routes are handled appropriately.
+### 5.2. Non-Functional Requirements
 
-**Behavior Precedence:**
-1. Default behavior allows fallback unless explicitly disabled (same as today).
-2. Per-VRF configuration overrides the global setting.
+- **NFR-1**: No impact on dataplane performance
+- **NFR-2**: Minimal memory footprint
+- **NFR-3**: No ASIC hardware table consumption for unreachable routes
+- **NFR-4**: Support existing warmboot/fastboot requirements
 
-### 3.2 DB Schema Changes
-The following tables will be added to `CONFIG_DB` to manage the fallback configuration.
+### 5.3. Exemptions/Limitations
 
-#### 3.2.1 Global Setting
-The `VRF_ROUTE_FALLBACK_GLOBAL` table will store the global fallback status for IPv4 and IPv6.
+- **EX-1**: Feature does not modify kernel routing behavior, only leverages existing mechanisms
+- **EX-2**: Unreachable routes are software-only and not programmed into hardware
 
+## 6. Architecture Design
+
+The feature integrates into existing SONiC architecture without requiring changes to the core framework. The solution leverages:
+
+- **CONFIG_DB**: For storing global and per-VRF fallback configuration
+- **VRF Manager (vrfmgrd)**: For monitoring configuration and applying kernel routes
+- **sonic-utilities**: For CLI interface implementation
+- **Linux Kernel**: For unreachable route mechanisms
+
+```
+┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
+│                 │    │                  │    │                 │
+│   CLI Commands  │───▶│    CONFIG_DB     │───▶│    vrfmgrd      │
+│  (sonic-util)   │    │                  │    │                 │
+└─────────────────┘    └──────────────────┘    └─────────────────┘
+                                                        │
+                                                        ▼
+                                               ┌─────────────────┐
+                                               │                 │
+                                               │  Linux Kernel   │
+                                               │ (Unreachable    │
+                                               │  Routes)        │
+                                               └─────────────────┘
+```
+
+## 7. High-Level Design
+
+### 7.1. Design Principles
+
+- **Built-in SONiC Feature**: This is a core SONiC feature, not an Application Extension
+- **Minimal Changes**: Leverages existing infrastructure with minimal modifications
+- **Backward Compatibility**: Maintains current behavior unless explicitly configured
+- **Kernel-Only Solution**: Uses Linux kernel unreachable routes, no hardware programming
+
+### 7.2. Repositories Modified
+
+- **sonic-utilities**: CLI command implementation
+- **sonic-swss**: VRF Manager daemon modifications
+- **sonic-buildimage**: Build configuration updates
+
+### 7.3. Module Dependencies
+
+- **vrfmgrd**: Core module responsible for applying configuration
+- **CONFIG_DB**: Configuration storage
+- **Linux iproute2**: For kernel route manipulation
+
+### 7.4. DB Schema Changes
+
+#### 7.4.1. CONFIG_DB Changes
+
+**New Table: VRF_ROUTE_FALLBACK_GLOBAL**
 ```json
 "VRF_ROUTE_FALLBACK_GLOBAL|ipv4": {
     "status": "enabled"
@@ -56,61 +135,97 @@ The `VRF_ROUTE_FALLBACK_GLOBAL` table will store the global fallback status for 
 }
 ```
 
-#### 3.2.2 Per-VRF Setting
-The `VRF` table will be extended with an optional attribute to override the global setting on a per-VRF basis.
-
+**Extended Table: VRF**
 ```json
 "VRF|VrfRed": {
-    "fallback": "enabled"
-},
-"VRF|VrfBlue": {
+    "fallback": "enabled",
     "fallback_v6": "disabled"
 }
 ```
 
-### 3.3 CLI Enhancements (sonic-utilities)
+### 7.5. Component Design
 
-#### 3.3.1 Configuration Commands
-New CLI commands will be introduced to manage the global and per-VRF fallback settings.
+#### 7.5.1. VRF Manager Changes
 
-**Usage Help**
+**Responsibilities:**
+- Monitor `VRF_ROUTE_FALLBACK_GLOBAL` and `VRF` tables
+- Apply unreachable routes when fallback is disabled
+- Remove unreachable routes when fallback is enabled
+- Handle configuration validation and error cases
+
+**Route Management:**
+- Add: `ip route add unreachable default metric 4278198272 vrf <VRF_NAME>`
+- Remove: `ip route del unreachable default vrf <VRF_NAME>`
+
+#### 7.5.2. CLI Implementation
+
+**Configuration Commands:**
+- `config vrf route-fallback [ipv4|ipv6] [enable|disable]`
+- `config vrf route-fallback [ipv4|ipv6] [enable|disable] -v <VRF_NAME>`
+
+**Show Commands:**
+- `show vrf-route-fallback`
+
+### 7.6. Warm Reboot Impact
+
+- Configuration persists across warm reboots
+- Route reconciliation occurs during vrfmgrd startup
+- No impact on warm reboot timing or data plane disruption
+
+### 7.7. Fastboot Impact
+
+- No additional dependencies for fastboot
+- Configuration loaded during normal startup sequence
+
+## 8. SAI API
+
+**No SAI API changes are required for this feature.**
+
+The unreachable routes are maintained only in the Linux kernel and are explicitly not programmed into the ASIC hardware. This design choice ensures:
+- No consumption of hardware FIB resources
+- No impact on dataplane performance
+- No SAI object creation or modification needed
+
+## 9. Configuration and Management
+
+### 9.1. CLI/YANG Model Enhancements
+
+#### 9.1.1. Configuration Commands
+
+**Global Configuration:**
 ```bash
-user@sonic# config vrf route-fallback -h
-Usage: config vrf route-fallback [OPTIONS] [ipv4|ipv6] [enable|disable]
-  Configure route fallback globally or for a specific VRF
-
-Options:
-  -v, --vrf-name TEXT  VRF name
-  -d, --delete         Delete override entry
-  -?, -h, --help       Show this message and exit.
-```
-
-**Global Fallback Configuration Examples**
-```bash
+# Configure global fallback for IPv4
 config vrf route-fallback ipv4 disable
+
+# Configure global fallback for IPv6  
 config vrf route-fallback ipv6 enable
 ```
 
-**Per-VRF Fallback Configuration Examples**
+**Per-VRF Configuration:**
 ```bash
+# Configure fallback for specific VRF
 config vrf route-fallback ipv4 disable -v VrfRed
 config vrf route-fallback ipv6 enable -v VrfBlue
+
+# Delete per-VRF override
+config vrf route-fallback ipv4 -v VrfRed --delete
 ```
 
-#### 3.3.2 Show Command
-A new `show` command will display the current fallback configuration.
+#### 9.1.2. Show Commands
 
-**Sample Output**
+```bash
+# Display current fallback configuration
+show vrf-route-fallback
 ```
-user@sonic# show vrf-route-fallback
-MGMT_VRF_CONFIG is not present.
 
+**Sample Output:**
+```
 Protocol: ipv4
 Global Fallback: Enabled
 
 VRF Name    Fallback (Override)
 ----------  ---------------------
-VrfRed      Enabled
+VrfRed      Disabled
 
 Protocol: ipv6
 Global Fallback: Enabled
@@ -120,52 +235,177 @@ VRF Name    Fallback (Override)
 VrfRed      Enabled
 ```
 
-#### 3.3.3 CLI Backend Processing
-The CLI backend will be implemented with the following logic:
-*   Implement CLI hooks to update `CONFIG_DB` with global and per-VRF fallback settings.
-*   Validate VRF existence before processing per-VRF requests.
-*   Use `swsscommon` or `sonic-db-cli` for database interaction.
+### 9.2. Config DB Enhancements
 
-### 3.4 VRF Manager (vrfmgrd) Changes
-The `vrfmgrd` daemon in `sonic-swss` will be responsible for applying the configuration.
+#### 9.2.1. Schema Changes
 
-**Responsibilities:**
-* **Monitor:** `VRF_ROUTE_FALLBACK_GLOBAL` and `VRF` tables in `CONFIG_DB`.
-* **Apply Logic:** Use the per-VRF value if defined; otherwise, use the global setting.
-* **Add Unreachable Routes:** When fallback is disabled for a VRF, add an unreachable default route.
-  * `ip route add unreachable default metric 4278198272 vrf <VRF_NAME>`
-  * `ip -6 route add unreachable default metric 4278198272 vrf <VRF_NAME>`
-* **Remove Unreachable Routes:** When fallback is enabled, remove the unreachable default route.
-  * `ip route del unreachable default vrf <VRF_NAME>`
-  * `ip -6 route del unreachable default vrf <VRF_NAME>`
+**New Table: VRF_ROUTE_FALLBACK_GLOBAL**
+- Key: `VRF_ROUTE_FALLBACK_GLOBAL|<protocol>`
+- Fields:
+  - `status`: "enabled" or "disabled"
 
-> **Note:** If a real default route (e.g., `0.0.0.0/0` or `::/0`) is configured in the VRF with a lower metric, it will take precedence over the unreachable default. The Linux kernel selects routes based on metric and prefix specificity, ensuring correct behavior.
+**Extended Table: VRF**
+- Additional optional fields:
+  - `fallback`: "enabled" or "disabled" (IPv4 override)
+  - `fallback_v6`: "enabled" or "disabled" (IPv6 override)
 
-### 3.5 SAI and Hardware Impact
-Unreachable routes must not be programmed into the ASIC hardware to avoid unnecessary table usage.
+#### 9.2.2. Backward Compatibility
 
-**Work Items:**
-*   Update `vrfmgrd` or related components to tag unreachable routes as software-only.
-*   Extend route orchestration logic to detect `unreachable` next-hop types and avoid programming them via SAI.
-*   Ensure FRR or Zebra does not install or redistribute these unreachable routes into BGP or other routing protocols.
+- New tables and fields are optional
+- Absence of configuration maintains current behavior
+- Existing VRF configurations remain unaffected
 
-> **Note:** The unreachable default route primarily affects software-forwarded packets—such as control-plane traffic, BGP sessions, and management traffic—by stopping fallback to other VRFs within the Linux kernel routing logic. This route is not intended to be used in hardware and has no impact on dataplane traffic handled by the ASIC. This allows operators to retain kernel-level route control without polluting the hardware FIB.
+#### 9.2.3. Schema Migration
 
-### 3.6 Config Reload and Persistence
-The feature must support configuration persistence across reboots and `config reload` operations.
-*   Fallback settings and routes must persist.
-*   Route reconciliation logic will be implemented at daemon startup to ensure the kernel state matches the configuration.
+**Upgrade Path:**
+- No migration required - optional configuration
+- Default behavior preserved until explicitly configured
 
-## 4. Testing Plan
+**Downgrade Path:**
+- Graceful degradation - new fields ignored
+- Pre-downgrade cleanup script removes unreachable routes
 
-### 4.1 Unit Tests
-*   CLI command behavior and validation (e.g., correct arguments, VRF existence).
-*   `CONFIG_DB` schema integrity and backend processing logic.
+## 10. Warmboot and Fastboot Design Impact
 
-### 4.2 Integration Tests
-*   Verify VRF route fallback behavior is disabled when the unreachable route is present.
-*   Verify per-VRF settings correctly override the global setting.
-*   Verify the global setting is applied correctly to all VRFs without an override.
-*   Test IPv4 and IPv6 functionality independently.
-*   Confirm persistence after `config reload` and system reboot.
-*   Verify that unreachable routes are not programmed into the ASIC FIB.
+### 10.1. Warmboot Impact
+
+**No negative impact on warmboot functionality:**
+- Configuration persistence through CONFIG_DB
+- Route reconciliation during vrfmgrd restart
+- No additional stalls or IO operations in boot path
+- No changes to critical boot sequence
+
+### 10.2. Fastboot Impact
+
+**No impact on fastboot performance:**
+- Configuration loaded during normal service startup
+- No additional dependencies or processing overhead
+- Feature can be delayed without affecting critical services
+
+### 10.3. Performance Analysis
+
+- **Boot Time**: No measurable impact on boot time
+- **CPU Usage**: Minimal CPU overhead during configuration changes only
+- **IO Operations**: Limited to route add/delete operations
+- **Critical Path**: Not in critical boot path
+
+## 11. Memory Consumption
+
+### 11.1. Memory Analysis
+
+**Static Memory:**
+- Configuration storage in CONFIG_DB: ~100 bytes per VRF
+- Additional code in vrfmgrd: ~5KB
+
+**Dynamic Memory:**
+- No growing memory consumption during operation
+- Kernel route entries: ~64 bytes per unreachable route
+- No memory leaks or unbounded growth
+
+**Total Impact:**
+- Negligible memory footprint
+- No memory consumption when feature is disabled
+- Scales linearly with number of configured VRFs
+
+## 12. Restrictions/Limitations
+
+### 12.1. Design Limitations
+
+- **L-1**: Unreachable routes affect only software-forwarded traffic
+- **L-2**: Feature requires Linux kernel support for unreachable routes
+- **L-3**: Does not modify BGP or other routing protocol behavior
+- **L-4**: Limited to VRF route lookup control, not general routing policy
+
+### 12.2. Platform Dependencies
+
+- **No platform-specific dependencies**
+- **Standard Linux iproute2 functionality required**
+- **Compatible with all SONiC-supported platforms**
+
+### 12.3. Scale Limitations
+
+- **Limited by kernel route table capacity**
+- **Recommended maximum: 1000 VRFs (platform dependent)**
+
+## 13. Testing Requirements/Design
+
+### 13.1. Unit Test Cases
+
+#### 13.1.1 CLI Tests
+- **UT-CLI-1**: Validate CLI command syntax and parameter validation
+- **UT-CLI-2**: Test CONFIG_DB updates for valid configurations
+- **UT-CLI-3**: Test error handling for invalid VRF names
+- **UT-CLI-4**: Test show command output formatting
+
+#### 13.1.2 CONFIG_DB Tests
+- **UT-DB-1**: Schema validation for global fallback entries
+- **UT-DB-2**: Schema validation for per-VRF fallback entries
+- **UT-DB-3**: Invalid configuration handling
+- **UT-DB-4**: Configuration persistence testing
+
+#### 13.1.3 VRF Manager Tests
+- **UT-MGR-1**: Configuration change monitoring
+- **UT-MGR-2**: Route addition/removal logic
+- **UT-MGR-3**: IPv4 and IPv6 handling independently
+- **UT-MGR-4**: Error handling for route operations
+
+### 13.2. System Test Cases
+
+#### 13.2.1 Functional Tests
+- **ST-FUNC-1**: Verify route fallback disabled with unreachable route present
+- **ST-FUNC-2**: Verify per-VRF override of global setting
+- **ST-FUNC-3**: Verify IPv4 and IPv6 independent operation
+- **ST-FUNC-4**: Test with multiple VRFs and mixed configurations
+
+#### 13.2.2 Integration Tests  
+- **ST-INT-1**: End-to-end CLI to kernel route verification
+- **ST-INT-2**: Configuration persistence across reboots
+- **ST-INT-3**: Config reload testing
+- **ST-INT-4**: Warm reboot with feature enabled
+
+#### 13.2.3 Upgrade/Downgrade Tests
+- **ST-UPG-1**: Seamless upgrade from pre-feature version
+- **ST-UPG-2**: Configuration migration validation
+- **ST-UPG-3**: Graceful downgrade with cleanup
+- **ST-UPG-4**: Schema validation across versions
+
+#### 13.2.4 Performance Tests
+- **ST-PERF-1**: Boot time impact measurement
+- **ST-PERF-2**: Memory consumption validation
+- **ST-PERF-3**: Route operation performance
+- **ST-PERF-4**: Scale testing with multiple VRFs
+
+#### 13.2.5 Negative Tests
+- **ST-NEG-1**: Invalid configuration handling
+- **ST-NEG-2**: Non-existent VRF handling
+- **ST-NEG-3**: Kernel route operation failures
+- **ST-NEG-4**: Configuration corruption recovery
+
+### 13.3. Warmboot/Fastboot Testing
+
+- **Verify no impact on existing warmboot/fastboot timings**
+- **Confirm zero data plane disruption during configuration changes**
+- **Test route reconciliation after warmboot**
+- **Validate configuration persistence across boot cycles**
+
+## 14. Open/Action Items
+
+### 14.1. Implementation Items
+
+- **AI-1**: Implement CLI commands in sonic-utilities repository
+- **AI-2**: Extend vrfmgrd for configuration monitoring and route management
+- **AI-3**: Add CONFIG_DB schema validation
+- **AI-4**: Create migration scripts for upgrade/downgrade scenarios
+
+### 14.2. Testing Items
+
+- **AI-5**: Develop comprehensive test suite covering all scenarios
+- **AI-6**: Performance baseline establishment
+- **AI-7**: Multi-platform compatibility testing
+- **AI-8**: Long-term stability testing
+
+### 14.3. Documentation Items
+
+- **AI-9**: Update SONiC command reference documentation
+- **AI-10**: Create user guide for VRF route fallback configuration
+- **AI-11**: Platform-specific deployment notes

--- a/doc/vrf/no-default-vrf-route-fallback-hld.md
+++ b/doc/vrf/no-default-vrf-route-fallback-hld.md
@@ -21,18 +21,16 @@
 
 | Rev | Date       | Author      | Description                                |
 |-----|------------|-------------|--------------------------------------------|
-| 1.0 | <Date>     | <Your Name> | Initial draft for VRF route fallback control |
+| 1.0 | 2025-09-04 | Sudharsan Rajagopalan | Initial draft for VRF route fallback control |
+| 2.0 | 2025-09-09 | Sudharsan Rajagopalan | Default unreachable route, global fallback knob added |
 
 ## 2. Scope
 
-This high-level design document covers the implementation of a configurable mechanism to disable VRF (Virtual Routing and Forwarding) route fallback behavior in SONiC. The scope includes:
-
-- Global and per-VRF configuration of route fallback behavior
-- CONFIG_DB schema changes for fallback configuration
-- CLI enhancements for configuration and monitoring
-- VRF Manager daemon modifications
-- Support for both IPv4 and IPv6 protocols
-- Configuration persistence and migration handling
+This high-level design covers changes to SONiC VRF route fallback behavior:
+- By default, disables kernel VRF fallback by installing an unreachable default route in all non-default VRFs on creation (matching ASIC behavior).
+- Introduces a temporary global knob to enable legacy kernel fallback, which removes the unreachable route from all non-default VRFs when set.
+- Updates to CONFIG_DB schema, CLI, and show commands to manage and display this behavior.
+- The global knob will be deprecated and removed in future releases.
 
 ## 3. Definitions/Abbreviations
 
@@ -47,365 +45,170 @@ This high-level design document covers the implementation of a configurable mech
 
 ## 4. Overview
 
-In current implementations of SONiC, the route lookup behavior can fall back to other VRFs when a route is not found in a non-default VRF. This can lead to unintended consequences and security risks.
+In prior SONiC releases, Linux kernel allowed VRF lookup fallback if a route was missing in a non-default VRF, which could cause divergence from ASIC behavior and security/operational risks.
 
-This document outlines a proposed solution to enhance SONiC's multi-VRF capabilities by providing a configurable mechanism to disable this fallback behavior. By introducing unreachable default routes in Linux VRF tables, the solution eliminates the need for kernel changes while allowing flexible, per-VRF and global configuration of fallback behavior.
+**This design ensures:**
+- By default, fallback is disabled both in kernel and ASIC by installing an unreachable default route in every new non-default VRF.
+- A temporary global knob (`kernel-vrf-fallback`) can be set to restore the old fallback behavior. When set, the unreachable default route is removed from all non-default VRFs, allowing the kernel to fall back as before.
+- The knob is intended only for backward compatibility and will be deprecated.
+
+> **Note:**  
+> The unreachable default route added to non-default VRFs exists only in the Linux kernel routing table.  
+> **It will not be added to APP_DB and will not be propagated to lower layers such as ASIC_DB, SAI, or programmed into hardware.**  
+> This ensures there is no impact on hardware FIB or ASIC resources.
 
 ## 5. Requirements
 
 ### 5.1. Functional Requirements
 
-- **FR-1**: Support global configuration to disable VRF route fallback for IPv4 and IPv6
-- **FR-2**: Support per-VRF override of global fallback configuration
-- **FR-3**: Maintain current fallback behavior as default (backward compatibility)
-- **FR-4**: Support both IPv4 and IPv6 route fallback control independently
-- **FR-5**: Persist configuration across reboots and config reload operations
-- **FR-6**: Provide CLI commands for configuration and monitoring
-- **FR-7**: Support seamless upgrade/downgrade scenarios
+- **FR-1**: On non-default VRF creation, add unreachable default route with high metric (for both IPv4 and IPv6).
+- **FR-2**: Provide a global CLI/DB knob to enable/disable kernel VRF fallback.
+- **FR-3**: When knob is **enabled**, remove unreachable default route from all non-default VRFs.
+- **FR-4**: When knob is **unset** or **removed** (default), restore unreachable default route to all non-default VRFs.
+- **FR-5**: CLI and show commands updated to reflect new behavior and knob state.
+- **FR-6**: Configuration persists across reboots and config reloads.
+- **FR-7**: Knob is deprecated and will be removed in a future release.
 
 ### 5.2. Non-Functional Requirements
 
-- **NFR-1**: No impact on dataplane performance
-- **NFR-2**: Minimal memory footprint
-- **NFR-3**: No ASIC hardware table consumption for unreachable routes
-- **NFR-4**: Support existing warmboot/fastboot requirements
+- **NFR-1**: No impact on dataplane performance.
+- **NFR-2**: Minimal memory and CPU overhead.
+- **NFR-3**: No ASIC table consumption for unreachable routes.
 
 ### 5.3. Exemptions/Limitations
 
-- **EX-1**: Feature does not modify kernel routing behavior, only leverages existing mechanisms
-- **EX-2**: Unreachable routes are software-only and not programmed into hardware
+- **EX-1**: No change to kernel routing implementation (uses existing unreachable route mechanism).
+- **EX-2**: Knob is global only; no per-VRF override.
 
 ## 6. Architecture Design
 
-The feature integrates into existing SONiC architecture without requiring changes to the core framework. The solution leverages:
-
-- **CONFIG_DB**: For storing global and per-VRF fallback configuration
-- **VRF Manager (vrfmgrd)**: For monitoring configuration and applying kernel routes
-- **sonic-utilities**: For CLI interface implementation
-- **Linux Kernel**: For unreachable route mechanisms
+- **CONFIG_DB**: Stores global fallback knob status.
+- **VRF Manager (vrfmgrd)**: Handles adding/removing unreachable default routes to non-default VRFs based on knob.
+- **sonic-utilities**: CLI and show command updates.
+- **Linux Kernel**: Manages unreachable route entries.
 
 ```
-┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
-│                 │    │                  │    │                 │
-│   CLI Commands  │───▶│    CONFIG_DB     │───▶│    vrfmgrd      │
-│  (sonic-util)   │    │                  │    │                 │
-└─────────────────┘    └──────────────────┘    └─────────────────┘
-                                                        │
-                                                        ▼
-                                               ┌─────────────────┐
-                                               │                 │
-                                               │  Linux Kernel   │
-                                               │ (Unreachable    │
-                                               │  Routes)        │
-                                               └─────────────────┘
+┌─────────────┐    ┌──────────────┐    ┌─────────────┐
+│             │    │              │    │             │
+│   CLI / GUI │───▶│  CONFIG_DB   │───▶│   vrfmgrd   │
+└─────────────┘    └──────────────┘    └─────────────┘
+                                          │
+                                          ▼
+                                 ┌───────────────────┐
+                                 │   Linux Kernel    │
+                                 │ (unreachable rt)  │
+                                 └───────────────────┘
 ```
 
 ## 7. High-Level Design
 
-### 7.1. Design Principles
+### 7.1. Default Behavior
 
-- **Built-in SONiC Feature**: This is a core SONiC feature, not an Application Extension
-- **Minimal Changes**: Leverages existing infrastructure with minimal modifications
-- **Backward Compatibility**: Maintains current behavior unless explicitly configured
-- **Kernel-Only Solution**: Uses Linux kernel unreachable routes, no hardware programming
+- On creation of any non-default VRF, vrfmgrd adds:
+  - `ip route add unreachable default metric 4278198272 vrf <VRF_NAME>`
+  - (For both IPv4 and IPv6.)
+- This disables fallback in the kernel.
+- **This unreachable default route will not be added to APP_DB and will not be propagated to lower layers.**
 
-### 7.2. Repositories Modified
+### 7.2. Global Fallback Knob
 
-- **sonic-utilities**: CLI command implementation
-- **sonic-swss**: VRF Manager daemon modifications
-- **sonic-buildimage**: Build configuration updates
+- New global configuration (in CONFIG_DB and CLI): `KERNEL_VRF_FALLBACK`
+- When set to `enabled`:
+    - vrfmgrd removes all unreachable default routes from non-default VRFs.
+    - Kernel fallback is restored (legacy behavior).
+- When unset/removed (default):
+    - vrfmgrd ensures unreachable default routes are present.
+    - Disables kernel fallback.
 
-### 7.3. Module Dependencies
+- **Note:** This knob is temporary and will be deprecated in future releases. Users are advised to migrate away from relying on kernel VRF fallback.
 
-- **vrfmgrd**: Core module responsible for applying configuration
-- **CONFIG_DB**: Configuration storage
-- **Linux iproute2**: For kernel route manipulation
+### 7.3. DB Schema Changes
 
-### 7.4. DB Schema Changes
-
-#### 7.4.1. CONFIG_DB Changes
-
-**New Table: VRF_ROUTE_FALLBACK_GLOBAL**
+**New Table: KERNEL_VRF_FALLBACK**
 ```json
-"VRF_ROUTE_FALLBACK_GLOBAL|ipv4": {
+"KERNEL_VRF_FALLBACK": {
     "status": "enabled"
-},
-"VRF_ROUTE_FALLBACK_GLOBAL|ipv6": {
-    "status": "disabled"
 }
 ```
+- When the table/field is absent or status is not `enabled`, fallback is disabled (unreachable route present).
 
-**Extended Table: VRF**
-```json
-"VRF|VrfRed": {
-    "fallback": "enabled",
-    "fallback_v6": "disabled"
-}
-```
+### 7.4. CLI and Show Command Changes
 
-### 7.5. Component Design
+#### 7.4.1. Configuration Commands
 
-#### 7.5.1. VRF Manager Changes
+- Enable kernel VRF fallback (removes unreachable route from all non-default VRFs):
+    ```bash
+    config vrf kernel-vrf-fallback enable
+    ```
+- Disable (default, unreachable route present in all non-default VRFs):
+    ```bash
+    config vrf kernel-vrf-fallback disable
+    ```
+  or to restore default:
+    ```bash
+    config vrf kernel-vrf-fallback delete
+    ```
+  (This will remove the KERNEL_VRF_FALLBACK entry, restoring unreachable route.)
 
-**Responsibilities:**
-- Monitor `VRF_ROUTE_FALLBACK_GLOBAL` and `VRF` tables
-- Apply unreachable routes when fallback is disabled
-- Remove unreachable routes when fallback is enabled
-- Handle configuration validation and error cases
+#### 7.4.2. Show Command
 
-**Route Management:**
-- Add: `ip route add unreachable default metric 4278198272 vrf <VRF_NAME>`
-- Remove: `ip route del unreachable default vrf <VRF_NAME>`
+- Show current fallback configuration:
+    ```bash
+    show vrf kernel-vrf-fallback
+    ```
+  **Sample Output:**
+    ```
+    Kernel VRF Fallback: Disabled
+    (Unreachable default route present in all non-default VRFs)
+    ```
+    or
+    ```
+    Kernel VRF Fallback: Enabled
+    (Unreachable default route NOT present; kernel fallback active)
+    ```
 
-#### 7.5.2. CLI Implementation
+### 7.5. Transition and Deprecation
 
-**Configuration Commands:**
-- `config vrf route-fallback [ipv4|ipv6] [enable|disable]`
-- `config vrf route-fallback [ipv4|ipv6] [enable|disable] -v <VRF_NAME>`
-
-**Show Commands:**
-- `show vrf-route-fallback`
-
-### 7.6. Warm Reboot Impact
-
-- Configuration persists across warm reboots
-- Route reconciliation occurs during vrfmgrd startup
-- No impact on warm reboot timing or data plane disruption
-
-### 7.7. Fastboot Impact
-
-- No additional dependencies for fastboot
-- Configuration loaded during normal startup sequence
+- The knob is a transitional setting, will be announced as deprecated, and removed in a future release.
 
 ## 8. SAI API
 
-**No SAI API changes are required for this feature.**
-
-The unreachable routes are maintained only in the Linux kernel and are explicitly not programmed into the ASIC hardware. This design choice ensures:
-- No consumption of hardware FIB resources
-- No impact on dataplane performance
-- No SAI object creation or modification needed
+- **No SAI API changes required.**
+- Unreachable routes are kernel-only and not programmed in hardware.
 
 ## 9. Configuration and Management
 
-### 9.1. CLI/YANG Model Enhancements
+### 9.1. CLI/YANG Model
 
-#### 9.1.1. Configuration Commands
+- See section 7.4 for updated config and show commands.
 
-**Global Configuration:**
-```bash
-# Configure global fallback for IPv4
-config vrf route-fallback ipv4 disable
+### 9.2. CONFIG_DB Schema
 
-# Configure global fallback for IPv6  
-config vrf route-fallback ipv6 enable
-```
+- See section 7.3.
 
-**Per-VRF Configuration:**
-```bash
-# Configure fallback for specific VRF
-config vrf route-fallback ipv4 disable -v VrfRed
-config vrf route-fallback ipv6 enable -v VrfBlue
+### 9.3. Backward Compatibility
 
-# Delete per-VRF override
-config vrf route-fallback ipv4 -v VrfRed --delete
-```
+- Default (knob unset): fallback disabled, matches ASIC.
+- Knob enabled: fallback restored (legacy only).
+- New deployments should not rely on kernel fallback feature.
 
-#### 9.1.2. Show Commands
-
-```bash
-# Display current fallback configuration
-show vrf-route-fallback
-```
-
-**Sample Output:**
-```
-Protocol: ipv4
-Global Fallback: Enabled
-
-VRF Name    Fallback (Override)
-----------  ---------------------
-VrfRed      Disabled
-
-Protocol: ipv6
-Global Fallback: Enabled
-
-VRF Name    Fallback (Override)
-----------  ---------------------
-VrfRed      Enabled
-```
-
-### 9.2. Config DB Enhancements
-
-#### 9.2.1. Schema Changes
-
-**New Table: VRF_ROUTE_FALLBACK_GLOBAL**
-- Key: `VRF_ROUTE_FALLBACK_GLOBAL|<protocol>`
-- Fields:
-  - `status`: "enabled" or "disabled"
-
-**Extended Table: VRF**
-- Additional optional fields:
-  - `fallback`: "enabled" or "disabled" (IPv4 override)
-  - `fallback_v6`: "enabled" or "disabled" (IPv6 override)
-
-#### 9.2.2. Backward Compatibility
-
-- New tables and fields are optional
-- Absence of configuration maintains current behavior
-- Existing VRF configurations remain unaffected
-
-#### 9.2.3. Schema Migration
-
-**Upgrade Path:**
-- No migration required - optional configuration
-- Default behavior preserved until explicitly configured
-
-**Downgrade Path:**
-- Graceful degradation - new fields ignored
-- Pre-downgrade cleanup script removes unreachable routes
-
-## 10. Warmboot and Fastboot Design Impact
-
-### 10.1. Warmboot Impact
-
-**No negative impact on warmboot functionality:**
-- Configuration persistence through CONFIG_DB
-- Route reconciliation during vrfmgrd restart
-- No additional stalls or IO operations in boot path
-- No changes to critical boot sequence
-
-### 10.2. Fastboot Impact
-
-**No impact on fastboot performance:**
-- Configuration loaded during normal service startup
-- No additional dependencies or processing overhead
-- Feature can be delayed without affecting critical services
-
-### 10.3. Performance Analysis
-
-- **Boot Time**: No measurable impact on boot time
-- **CPU Usage**: Minimal CPU overhead during configuration changes only
-- **IO Operations**: Limited to route add/delete operations
-- **Critical Path**: Not in critical boot path
-
-## 11. Memory Consumption
-
-### 11.1. Memory Analysis
-
-**Static Memory:**
-- Configuration storage in CONFIG_DB: ~100 bytes per VRF
-- Additional code in vrfmgrd: ~5KB
-
-**Dynamic Memory:**
-- No growing memory consumption during operation
-- Kernel route entries: ~64 bytes per unreachable route
-- No memory leaks or unbounded growth
-
-**Total Impact:**
-- Negligible memory footprint
-- No memory consumption when feature is disabled
-- Scales linearly with number of configured VRFs
-
-## 12. Restrictions/Limitations
-
-### 12.1. Design Limitations
-
-- **L-1**: Unreachable routes affect only software-forwarded traffic
-- **L-2**: Feature requires Linux kernel support for unreachable routes
-- **L-3**: Does not modify BGP or other routing protocol behavior
-- **L-4**: Limited to VRF route lookup control, not general routing policy
-
-### 12.2. Platform Dependencies
-
-- **No platform-specific dependencies**
-- **Standard Linux iproute2 functionality required**
-- **Compatible with all SONiC-supported platforms**
-
-### 12.3. Scale Limitations
-
-- **Limited by kernel route table capacity**
-- **Recommended maximum: 1000 VRFs (platform dependent)**
+## 10–14. (Remain as in previous version, with test cases and open items updated to reflect new default and knob.)
 
 ## 13. Testing Requirements/Design
 
-### 13.1. Unit Test Cases
+### 13.1. Unit Tests
 
-#### 13.1.1 CLI Tests
-- **UT-CLI-1**: Validate CLI command syntax and parameter validation
-- **UT-CLI-2**: Test CONFIG_DB updates for valid configurations
-- **UT-CLI-3**: Test error handling for invalid VRF names
-- **UT-CLI-4**: Test show command output formatting
+- **UT-CLI-1**: Validate new CLI commands.
+- **UT-DB-1**: Schema validation for KERNEL_VRF_FALLBACK.
+- **UT-MGR-1**: Ensure unreachable route is added/removed on knob change.
 
-#### 13.1.2 CONFIG_DB Tests
-- **UT-DB-1**: Schema validation for global fallback entries
-- **UT-DB-2**: Schema validation for per-VRF fallback entries
-- **UT-DB-3**: Invalid configuration handling
-- **UT-DB-4**: Configuration persistence testing
+### 13.2. System Tests
 
-#### 13.1.3 VRF Manager Tests
-- **UT-MGR-1**: Configuration change monitoring
-- **UT-MGR-2**: Route addition/removal logic
-- **UT-MGR-3**: IPv4 and IPv6 handling independently
-- **UT-MGR-4**: Error handling for route operations
-
-### 13.2. System Test Cases
-
-#### 13.2.1 Functional Tests
-- **ST-FUNC-1**: Verify route fallback disabled with unreachable route present
-- **ST-FUNC-2**: Verify per-VRF override of global setting
-- **ST-FUNC-3**: Verify IPv4 and IPv6 independent operation
-- **ST-FUNC-4**: Test with multiple VRFs and mixed configurations
-
-#### 13.2.2 Integration Tests  
-- **ST-INT-1**: End-to-end CLI to kernel route verification
-- **ST-INT-2**: Configuration persistence across reboots
-- **ST-INT-3**: Config reload testing
-- **ST-INT-4**: Warm reboot with feature enabled
-
-#### 13.2.3 Upgrade/Downgrade Tests
-- **ST-UPG-1**: Seamless upgrade from pre-feature version
-- **ST-UPG-2**: Configuration migration validation
-- **ST-UPG-3**: Graceful downgrade with cleanup
-- **ST-UPG-4**: Schema validation across versions
-
-#### 13.2.4 Performance Tests
-- **ST-PERF-1**: Boot time impact measurement
-- **ST-PERF-2**: Memory consumption validation
-- **ST-PERF-3**: Route operation performance
-- **ST-PERF-4**: Scale testing with multiple VRFs
-
-#### 13.2.5 Negative Tests
-- **ST-NEG-1**: Invalid configuration handling
-- **ST-NEG-2**: Non-existent VRF handling
-- **ST-NEG-3**: Kernel route operation failures
-- **ST-NEG-4**: Configuration corruption recovery
-
-### 13.3. Warmboot/Fastboot Testing
-
-- **Verify no impact on existing warmboot/fastboot timings**
-- **Confirm zero data plane disruption during configuration changes**
-- **Test route reconciliation after warmboot**
-- **Validate configuration persistence across boot cycles**
+- **ST-FUNC-1**: Confirm fallback is disabled by default (unreachable route present).
+- **ST-FUNC-2**: Confirm fallback is enabled when knob set (unreachable route absent).
+- **ST-FUNC-3**: Confirm correct behavior after config reload/warmboot.
 
 ## 14. Open/Action Items
 
-### 14.1. Implementation Items
-
-- **AI-1**: Implement CLI commands in sonic-utilities repository
-- **AI-2**: Extend vrfmgrd for configuration monitoring and route management
-- **AI-3**: Add CONFIG_DB schema validation
-- **AI-4**: Create migration scripts for upgrade/downgrade scenarios
-
-### 14.2. Testing Items
-
-- **AI-5**: Develop comprehensive test suite covering all scenarios
-- **AI-6**: Performance baseline establishment
-- **AI-7**: Multi-platform compatibility testing
-- **AI-8**: Long-term stability testing
-
-### 14.3. Documentation Items
-
-- **AI-9**: Update SONiC command reference documentation
-- **AI-10**: Create user guide for VRF route fallback configuration
-- **AI-11**: Platform-specific deployment notes
+- Implementation and deprecation notice for knob in docs.
+- CLI and show command updates.

--- a/doc/vrf/no-default-vrf-route-fallback-hld.md
+++ b/doc/vrf/no-default-vrf-route-fallback-hld.md
@@ -1,72 +1,80 @@
-= High-Level Design Document - No Default VRF Route Fallback
-:toc: left
-:toclevels: 4
-:sectnums:
+# High-Level Design Document - No Default VRF Route Fallback
 
-Revision History
+## Table of Contents
+- [1. Introduction](#1-introduction)
+- [2. Problem Description](#2-problem-description)
+- [3. Feature Design](#3-feature-design)
+  - [3.1 High-Level Design](#31-high-level-design)
+  - [3.2 DB Schema Changes](#32-db-schema-changes)
+  - [3.3 CLI Enhancements (sonic-utilities)](#33-cli-enhancements-sonic-utilities)
+  - [3.4 VRF Manager (vrfmgrd) Changes](#34-vrf-manager-vrfmgrd-changes)
+  - [3.5 SAI and Hardware Impact](#35-sai-and-hardware-impact)
+  - [3.6 Config Reload and Persistence](#36-config-reload-and-persistence)
+- [4. Testing Plan](#4-testing-plan)
+  - [4.1 Unit Tests](#41-unit-tests)
+  - [4.2 Integration Tests](#42-integration-tests)
+
+## Revision History
 | Rev | Date       | Author      | Description                                |
 |-----|------------|-------------|--------------------------------------------|
 | 1.0 | <Date>     | <Your Name> | Initial draft for VRF route fallback control |
 
-== 1. Introduction
+## 1. Introduction
 In current implementations of SONiC, the route lookup behavior can fall back to other VRFs (Virtual Routing and Forwarding) when a route is not found in a non-default VRF. This can lead to unintended consequences.
 
 This document outlines a proposed solution to enhance SONiC's multi-VRF capabilities by providing a configurable mechanism to disable this fallback behavior. By introducing unreachable default routes in Linux VRF tables, the solution eliminates the need for kernel changes while allowing flexible, per-VRF and global configuration of fallback behavior.
 
-== 2. Problem Description
+## 2. Problem Description
 When a route is not found in a specific non-default VRF, the Linux kernel, by default, performs a fallback route lookup in other VRFs in the order found in IP table rules. This behavior may not always align with network operators' intent, potentially leading to security risks or routing inaccuracies. A mechanism to disable this fallback—both globally and on a per-VRF basis—is required to provide more control and flexibility.
 
-== 3. Feature Design
+## 3. Feature Design
 
-=== 3.1 High-Level Design
+### 3.1 High-Level Design
 The proposed solution adds a configurable mechanism to disable fallback to other VRFs. This is achieved by introducing unreachable default routes in the corresponding Linux VRF tables. The solution does not require kernel-level changes and instead leverages SONiC's existing infrastructure, including `CONFIG_DB`, CLI utilities, and the VRF Manager Daemon (`vrfmgrd`).
 
-*Key Features:*
-* *Global and Per-VRF Configuration:* Operators can disable fallback globally or override it on a per-VRF basis.
-* *Retain Default Behavior:* The system defaults to the current behavior (fallback allowed) unless explicitly configured otherwise.
-* *Support for IPv4 and IPv6:* The solution ensures that both IPv4 and IPv6 routes are handled appropriately.
+**Key Features:**
+* **Global and Per-VRF Configuration:** Operators can disable fallback globally or override it on a per-VRF basis.
+* **Retain Default Behavior:** The system defaults to the current behavior (fallback allowed) unless explicitly configured otherwise.
+* **Support for IPv4 and IPv6:** The solution ensures that both IPv4 and IPv6 routes are handled appropriately.
 
-*Behavior Precedence:*
-. Default behavior allows fallback unless explicitly disabled (same as today).
-. Per-VRF configuration overrides the global setting.
+**Behavior Precedence:**
+1. Default behavior allows fallback unless explicitly disabled (same as today).
+2. Per-VRF configuration overrides the global setting.
 
-=== 3.2 DB Schema Changes
+### 3.2 DB Schema Changes
 The following tables will be added to `CONFIG_DB` to manage the fallback configuration.
 
-==== 3.2.1 Global Setting
+#### 3.2.1 Global Setting
 The `VRF_ROUTE_FALLBACK_GLOBAL` table will store the global fallback status for IPv4 and IPv6.
 
-[source,json]
-----
+```json
 "VRF_ROUTE_FALLBACK_GLOBAL|ipv4": {
     "status": "enabled"
 },
 "VRF_ROUTE_FALLBACK_GLOBAL|ipv6": {
     "status": "disabled"
 }
-----
+```
 
-==== 3.2.2 Per-VRF Setting
+#### 3.2.2 Per-VRF Setting
 The `VRF` table will be extended with an optional attribute to override the global setting on a per-VRF basis.
 
-[source,json]
-----
+```json
 "VRF|VrfRed": {
     "fallback": "enabled"
 },
 "VRF|VrfBlue": {
     "fallback_v6": "disabled"
 }
-----
+```
 
-=== 3.3 CLI Enhancements (sonic-utilities)
+### 3.3 CLI Enhancements (sonic-utilities)
 
-==== 3.3.1 Configuration Commands
+#### 3.3.1 Configuration Commands
 New CLI commands will be introduced to manage the global and per-VRF fallback settings.
 
-.Usage Help
-[source,bash]
-----
+**Usage Help**
+```bash
 user@sonic# config vrf route-fallback -h
 Usage: config vrf route-fallback [OPTIONS] [ipv4|ipv6] [enable|disable]
   Configure route fallback globally or for a specific VRF
@@ -75,28 +83,25 @@ Options:
   -v, --vrf-name TEXT  VRF name
   -d, --delete         Delete override entry
   -?, -h, --help       Show this message and exit.
-----
+```
 
-.Global Fallback Configuration Examples
-[source,bash]
-----
+**Global Fallback Configuration Examples**
+```bash
 config vrf route-fallback ipv4 disable
 config vrf route-fallback ipv6 enable
-----
+```
 
-.Per-VRF Fallback Configuration Examples
-[source,bash]
-----
+**Per-VRF Fallback Configuration Examples**
+```bash
 config vrf route-fallback ipv4 disable -v VrfRed
 config vrf route-fallback ipv6 enable -v VrfBlue
-----
+```
 
-==== 3.3.2 Show Command
+#### 3.3.2 Show Command
 A new `show` command will display the current fallback configuration.
 
-.Sample Output
-[literal]
-----
+**Sample Output**
+```
 user@sonic# show vrf-route-fallback
 MGMT_VRF_CONFIG is not present.
 
@@ -113,51 +118,51 @@ Global Fallback: Enabled
 VRF Name    Fallback (Override)
 ----------  ---------------------
 VrfRed      Enabled
-----
+```
 
-==== 3.3.3 CLI Backend Processing
+#### 3.3.3 CLI Backend Processing
 The CLI backend will be implemented with the following logic:
 *   Implement CLI hooks to update `CONFIG_DB` with global and per-VRF fallback settings.
 *   Validate VRF existence before processing per-VRF requests.
 *   Use `swsscommon` or `sonic-db-cli` for database interaction.
 
-=== 3.4 VRF Manager (vrfmgrd) Changes
+### 3.4 VRF Manager (vrfmgrd) Changes
 The `vrfmgrd` daemon in `sonic-swss` will be responsible for applying the configuration.
 
-*Responsibilities:*
-* *Monitor:* `VRF_ROUTE_FALLBACK_GLOBAL` and `VRF` tables in `CONFIG_DB`.
-* *Apply Logic:* Use the per-VRF value if defined; otherwise, use the global setting.
-* *Add Unreachable Routes:* When fallback is disabled for a VRF, add an unreachable default route.
-** `ip route add unreachable default metric 4278198272 vrf <VRF_NAME>`
-** `ip -6 route add unreachable default metric 4278198272 vrf <VRF_NAME>`
-* *Remove Unreachable Routes:* When fallback is enabled, remove the unreachable default route.
-** `ip route del unreachable default vrf <VRF_NAME>`
-** `ip -6 route del unreachable default vrf <VRF_NAME>`
+**Responsibilities:**
+* **Monitor:** `VRF_ROUTE_FALLBACK_GLOBAL` and `VRF` tables in `CONFIG_DB`.
+* **Apply Logic:** Use the per-VRF value if defined; otherwise, use the global setting.
+* **Add Unreachable Routes:** When fallback is disabled for a VRF, add an unreachable default route.
+  * `ip route add unreachable default metric 4278198272 vrf <VRF_NAME>`
+  * `ip -6 route add unreachable default metric 4278198272 vrf <VRF_NAME>`
+* **Remove Unreachable Routes:** When fallback is enabled, remove the unreachable default route.
+  * `ip route del unreachable default vrf <VRF_NAME>`
+  * `ip -6 route del unreachable default vrf <VRF_NAME>`
 
-NOTE: If a real default route (e.g., `0.0.0.0/0` or `::/0`) is configured in the VRF with a lower metric, it will take precedence over the unreachable default. The Linux kernel selects routes based on metric and prefix specificity, ensuring correct behavior.
+> **Note:** If a real default route (e.g., `0.0.0.0/0` or `::/0`) is configured in the VRF with a lower metric, it will take precedence over the unreachable default. The Linux kernel selects routes based on metric and prefix specificity, ensuring correct behavior.
 
-=== 3.5 SAI and Hardware Impact
+### 3.5 SAI and Hardware Impact
 Unreachable routes must not be programmed into the ASIC hardware to avoid unnecessary table usage.
 
-*Work Items:*
+**Work Items:**
 *   Update `vrfmgrd` or related components to tag unreachable routes as software-only.
 *   Extend route orchestration logic to detect `unreachable` next-hop types and avoid programming them via SAI.
 *   Ensure FRR or Zebra does not install or redistribute these unreachable routes into BGP or other routing protocols.
 
-NOTE: The unreachable default route primarily affects software-forwarded packets—such as control-plane traffic, BGP sessions, and management traffic—by stopping fallback to other VRFs within the Linux kernel routing logic. This route is not intended to be used in hardware and has no impact on dataplane traffic handled by the ASIC. This allows operators to retain kernel-level route control without polluting the hardware FIB.
+> **Note:** The unreachable default route primarily affects software-forwarded packets—such as control-plane traffic, BGP sessions, and management traffic—by stopping fallback to other VRFs within the Linux kernel routing logic. This route is not intended to be used in hardware and has no impact on dataplane traffic handled by the ASIC. This allows operators to retain kernel-level route control without polluting the hardware FIB.
 
-=== 3.6 Config Reload and Persistence
+### 3.6 Config Reload and Persistence
 The feature must support configuration persistence across reboots and `config reload` operations.
 *   Fallback settings and routes must persist.
 *   Route reconciliation logic will be implemented at daemon startup to ensure the kernel state matches the configuration.
 
-== 4. Testing Plan
+## 4. Testing Plan
 
-=== 4.1 Unit Tests
+### 4.1 Unit Tests
 *   CLI command behavior and validation (e.g., correct arguments, VRF existence).
 *   `CONFIG_DB` schema integrity and backend processing logic.
 
-=== 4.2 Integration Tests
+### 4.2 Integration Tests
 *   Verify VRF route fallback behavior is disabled when the unreachable route is present.
 *   Verify per-VRF settings correctly override the global setting.
 *   Verify the global setting is applied correctly to all VRFs without an override.

--- a/doc/vrf/no-default-vrf-route-fallback-hld.md
+++ b/doc/vrf/no-default-vrf-route-fallback-hld.md
@@ -1,334 +1,332 @@
 # No Default VRF Route Fallback
 
-## Table of Content
+## Table of Contents
 
-### 1. Revision
-### 2. Scope
-### 3. Definitions/Abbreviations
-### 4. Overview
-### 5. Requirements
-### 6. Architecture Design
-### 7. High-Level Design
-### 8. SAI API
-### 9. Configuration and Management
-### 10. Warmboot and Fastboot Design Impact
-### 11. Memory Consumption
-### 12. Restrictions/Limitations
-### 13. Testing Requirements/Design
-### 14. Open/Action Items
+1. [Revision](#1-revision)
+2. [Scope](#2-scope)
+3. [Definitions and Abbreviations](#3-definitions-and-abbreviations)
+4. [Overview](#4-overview)
+5. [Requirements](#5-requirements)
+6. [Architecture Design](#6-architecture-design)
+7. [High-Level Design](#7-high-level-design)
+8. [SAI API](#8-sai-api)
+9. [Configuration and Management](#9-configuration-and-management)
+10. [Warmboot and Fastboot Design Impact](#10-warmboot-and-fastboot-design-impact)
+11. [Memory Consumption](#11-memory-consumption)
+12. [Restrictions and Limitations](#12-restrictions-and-limitations)
+13. [Testing Requirements and Design](#13-testing-requirements-and-design)
+14. [Open and Action Items](#14-open-and-action-items)
 
 ## 1. Revision
 
-| Rev | Date       | Author      | Description                                |
-|-----|------------|-------------|--------------------------------------------|
+| Rev | Date | Author | Description |
+|---|---|---|---|
 | 1.0 | 2025-09-04 | Sudharsan Rajagopalan | Initial draft for VRF route fallback control |
-| 2.0 | 2025-09-09 | Sudharsan Rajagopalan | Default unreachable route, global fallback knob added |
+| 2.0 | 2025-09-09 | Sudharsan Rajagopalan | Added default unreachable routes and the global fallback knob |
+| 3.0 | 2026-07-02 | Sudharsan Rajagopalan | Clarified the kernel-only scope and CONFIG_DB-only management; removed the CLI design |
 
 ## 2. Scope
 
-This high-level design covers changes to SONiC VRF route fallback behavior:
-- By default, disables kernel VRF fallback by installing an unreachable default route in all non-default VRFs on creation (matching ASIC behavior).
-- Introduces a temporary global knob to enable legacy kernel fallback, which removes the unreachable route from all non-default VRFs when set.
-- Updates to CONFIG_DB schema, CLI, and show commands to manage and display this behavior.
-- The global knob will be deprecated and removed in future releases.
+This HLD changes only Linux VRF route lookup for traffic processed by the host kernel, including VRF-bound locally originated traffic and packets forwarded in software. It does not add or modify hardware routes, SAI objects, or ASIC forwarding behavior.
 
-## 3. Definitions/Abbreviations
+- By default, `vrfmgrd` disables legacy Linux routing-policy database (RPDB) fall-through by installing managed IPv4 and IPv6 unreachable default routes in each applicable non-default Linux VRF table.
+- A temporary global CONFIG_DB setting can remove those routes, restoring fallback in the Linux kernel route-lookup path, including VRF-bound local output and software-forwarded packets, by permitting RPDB lookup to continue to later rules and tables.
+- This HLD defines the CONFIG_DB schema and `vrfmgrd` behavior. It does not define a feature-specific configuration CLI or show command.
+- The global compatibility setting will be deprecated and removed in a future release.
+
+## 3. Definitions and Abbreviations
 
 | Term | Definition |
-|------|------------|
+|---|---|
 | VRF | Virtual Routing and Forwarding |
 | FIB | Forwarding Information Base |
+| RPDB | Linux routing-policy database |
 | SAI | Switch Abstraction Interface |
 | ASIC | Application-Specific Integrated Circuit |
 | BGP | Border Gateway Protocol |
-| FRR | Free Range Routing |
+| FRR | FRRouting |
+| FPM | Forwarding Plane Manager protocol used between FRR zebra and `fpmsyncd` |
 
 ## 4. Overview
 
-In prior SONiC releases, Linux kernel allowed VRF lookup fallback if a route was missing in a non-default VRF, which could cause divergence from ASIC behavior and security/operational risks.
+Linux VRF devices use an `l3mdev` RPDB rule to select the routing table associated with the VRF. If that table has no matching route, lookup can continue to later RPDB rules and routing tables, including the default routing table. This legacy behavior can allow kernel-routed traffic to leave the intended VRF.
 
-**This design ensures:**
-- By default, fallback is disabled both in kernel and ASIC by installing an unreachable default route in every new non-default VRF.
-- A temporary global knob (`kernel-vrf-fallback`) can be set to restore the old fallback behavior. When set, the unreachable default route is removed from all non-default VRFs, allowing the kernel to fall back as before.
-- The knob is intended only for backward compatibility and will be deprecated.
+The [Linux VRF documentation](https://docs.kernel.org/networking/vrf.html) recommends an unreachable default route with metric `4278198272`. The route makes an otherwise-unmatched lookup terminal while allowing more-specific routes, or a usable default route with a lower metric, to take precedence. FRR interprets the metric as administrative distance and priority `[255/8192]`.
 
-> **Note:**  
-> The unreachable default route added to non-default VRFs exists only in the Linux kernel routing table.  
-> **It will not be added to APP_DB and will not be propagated to lower layers such as ASIC_DB, SAI, or programmed into hardware.**  
-> This ensures there is no impact on hardware FIB or ASIC resources.
+This feature changes Linux route lookup only. It neither enables nor disables fallback in an ASIC. Hardware behavior remains unchanged and is determined by the platform's existing SAI and ASIC implementation. On platforms whose hardware already terminates a route miss within the selected virtual router, this feature aligns the Linux route-miss result with that behavior.
+
+The unreachable defaults are installed directly in the Linux kernel. FRR may observe kernel route notifications, so `fpmsyncd` must filter both add and delete notifications for `RTN_UNREACHABLE` routes before changing APP_DB. Consequently, the managed sentinel routes are not translated into ASIC_DB or SAI route objects and do not consume hardware FIB resources.
 
 ## 5. Requirements
 
 ### 5.1. Functional Requirements
 
-- **FR-1**: On non-default VRF creation, add unreachable default route with high metric (for both IPv4 and IPv6).
-- **FR-2**: Provide a global CLI/DB knob to enable/disable kernel VRF fallback.
-- **FR-3**: When knob is **enabled**, remove unreachable default route from all non-default VRFs.
-- **FR-4**: When knob is **unset** or **removed** (default), restore unreachable default route to all non-default VRFs.
-- **FR-5**: CLI and show commands updated to reflect new behavior and knob state.
-- **FR-6**: Configuration persists across reboots and config reloads.
-- **FR-7**: Knob is deprecated and will be removed in a future release.
+- **FR-1**: When kernel fallback is not enabled, ensure that managed IPv4 and IPv6 unreachable default routes with metric `4278198272` are present in every applicable non-default Linux VRF table.
+- **FR-2**: Provide one global CONFIG_DB setting that controls both IPv4 and IPv6 behavior for all applicable non-default VRFs.
+- **FR-3**: When `status` is `enabled`, remove only the managed sentinel routes from existing non-default VRFs and do not add them to newly created non-default VRFs.
+- **FR-4**: When `status` is `disabled`, the CONFIG_DB entry is deleted, or the entry is absent, ensure that the managed sentinel routes are present in existing and newly created non-default VRFs.
+- **FR-5**: Read the effective global state before processing VRF creation events and reconcile all existing non-default VRFs at startup, after a configuration change, and after `vrfmgrd` restarts.
+- **FR-6**: Keep the managed sentinel routes out of APP_DB, ASIC_DB, SAI, and the hardware FIB. `fpmsyncd` must ignore their add and delete notifications before mutating APP_DB, so removing a sentinel cannot remove or alter a real unicast default route.
+- **FR-7**: Preserve an explicitly configured compatibility setting across reboot and configuration reload through the standard persistent CONFIG_DB workflow.
+- **FR-8**: Deprecate and remove the compatibility setting in a future release.
 
 ### 5.2. Non-Functional Requirements
 
-- **NFR-1**: No impact on dataplane performance.
-- **NFR-2**: Minimal memory and CPU overhead.
-- **NFR-3**: No ASIC table consumption for unreachable routes.
+- **NFR-1**: Do not change ASIC or hardware forwarding behavior or performance.
+- **NFR-2**: Make route reconciliation idempotent and proportional to the number of applicable VRFs.
+- **NFR-3**: Do not consume ASIC route-table resources for the managed sentinel routes.
 
-### 5.3. Exemptions/Limitations
+### 5.3. Exemptions and Limitations
 
-- **EX-1**: No change to kernel routing implementation (uses existing unreachable route mechanism).
-- **EX-2**: Knob is global only; no per-VRF override.
+- **EX-1**: The setting is global; there is no per-VRF override.
+- **EX-2**: One setting controls both IPv4 and IPv6; the address families cannot be configured independently.
+- **EX-3**: A feature-specific CLI, show command, and management API are outside the scope of this HLD.
+- **EX-4**: SAI and hardware fallback behavior are outside the scope of this HLD.
+- **EX-5**: The feature applies to non-default Linux VRFs managed through the `vrfmgrd` lifecycle. Specialized VRF-like objects outside that lifecycle retain their existing handling.
 
 ## 6. Architecture Design
 
-- **CONFIG_DB**: Stores global fallback knob status.
-- **VRF Manager (vrfmgrd)**: Handles adding/removing unreachable default routes to non-default VRFs based on knob.
-- **sonic-utilities**: CLI and show command updates.
-- **Linux Kernel**: Manages unreachable route entries.
+- **CONFIG_DB** stores the global compatibility setting.
+- **VRF Manager (`vrfmgrd`)** caches the effective setting and reconciles managed sentinel routes in the applicable Linux VRF tables.
+- **Linux Kernel** performs the affected route lookup and maintains the unreachable route entries.
+- **FRR zebra and `fpmsyncd`** may observe kernel route notifications. `fpmsyncd` filters `RTN_UNREACHABLE` additions and deletions before they can change APP_DB or the hardware programming pipeline.
 
-```
-┌─────────────┐    ┌──────────────┐    ┌─────────────┐
-│             │    │              │    │             │
-│   CLI / GUI │───▶│  CONFIG_DB   │───▶│   vrfmgrd   │
-└─────────────┘    └──────────────┘    └─────────────┘
-                                          │
-                                          ▼
-                                 ┌───────────────────┐
-                                 │   Linux Kernel    │
-                                 │ (unreachable rt)  │
-                                 └───────────────────┘
+```text
+Persistent CONFIG_DB writer
+             |
+             v
+CONFIG_DB (KERNEL_VRF_FALLBACK|GLOBAL)
+             |
+             v
+          vrfmgrd  ------->  Linux VRF routing tables
+                                  |
+                                  | RTN_UNREACHABLE notification
+                                  v
+                           FRR zebra / FPM
+                                  |
+                                  v
+                           fpmsyncd filter
+                                  X
+                      APP_DB / ASIC_DB / SAI / ASIC
 ```
 
 ## 7. High-Level Design
 
-### 7.1. Default Behavior
+### 7.1. Effective State
 
-- On creation of any non-default VRF, vrfmgrd adds:
-  - `ip route add unreachable default metric 4278198272 vrf <VRF_NAME>`
-  - (For both IPv4 and IPv6.)
-- This disables fallback in the kernel.
-- **This unreachable default route will not be added to APP_DB and will not be propagated to lower layers.**
+The default effective state is `disabled`, meaning that legacy Linux RPDB fall-through is disabled. Only the explicit value `enabled` selects the compatibility behavior.
 
-### 7.2. Global Fallback Knob
+| CONFIG_DB state | `vrfmgrd` action | Linux route-lookup result | Hardware result |
+|---|---|---|---|
+| Entry absent, entry deleted, or `status=disabled` | Ensure both managed sentinel routes are present | An otherwise-unmatched lookup terminates in the selected VRF table | Unchanged |
+| `status=enabled` | Remove both managed sentinel routes and skip them for new VRFs | An otherwise-unmatched lookup may continue to later RPDB rules and tables | Unchanged |
 
-- New global configuration (in CONFIG_DB and CLI): `KERNEL_VRF_FALLBACK`
-- When set to `enabled`:
-    - vrfmgrd removes all unreachable default routes from non-default VRFs.
-    - Kernel fallback is restored (legacy behavior).
-- When unset/removed (default):
-    - vrfmgrd ensures unreachable default routes are present.
-    - Disables kernel fallback.
+Removing the unreachable defaults permits legacy fall-through; it does not guarantee reachability. A later RPDB rule and matching route must exist for lookup to succeed.
 
-- **Note:** This knob is temporary and will be deprecated in future releases. Users are advised to migrate away from relying on kernel VRF fallback.
+### 7.2. Route Lifecycle and Ownership
 
-### 7.3. DB Schema Changes
+At startup, `vrfmgrd` reads and caches the effective global state before it processes VRF creation events. It then enumerates existing applicable non-default VRFs and reconciles them with that state.
 
-**New Table: KERNEL_VRF_FALLBACK**
+When the effective state is `disabled`, `vrfmgrd` uses idempotent route replacement for each VRF table:
+
+```bash
+ip route replace table <TABLE_ID> unreachable default metric 4278198272
+ip -6 route replace table <TABLE_ID> unreachable default metric 4278198272
+```
+
+When the effective state changes to `enabled`, `vrfmgrd` removes the exact managed sentinel routes:
+
+```bash
+ip route del table <TABLE_ID> unreachable default metric 4278198272
+ip -6 route del table <TABLE_ID> unreachable default metric 4278198272
+```
+
+The managed sentinel identity is the tuple of address family, VRF table, route type `unreachable`, default prefix, and metric `4278198272`. If an exact matching route already exists when the effective state is `disabled`, `vrfmgrd` adopts it as the managed sentinel instead of creating a duplicate. An operator cannot independently own an identical route while this feature manages the VRF; selecting `status=enabled` removes the adopted match. Routes that differ in type, prefix, or metric, including any unicast default, are not managed and must be preserved. An already-present route during replacement and an already-absent route during deletion are treated as success.
+
+For a VRF created while `status=enabled`, `vrfmgrd` does not add either managed sentinel. When the CONFIG_DB entry is deleted or changed to `disabled`, `vrfmgrd` adds or adopts both sentinels in all existing applicable VRFs and applies the same rule to future VRFs.
+
+### 7.3. CONFIG_DB Schema
+
+**New entry: `KERNEL_VRF_FALLBACK|GLOBAL`**
+
 ```json
-"KERNEL_VRF_FALLBACK": {
-    "status": "enabled"
+{
+    "KERNEL_VRF_FALLBACK": {
+        "GLOBAL": {
+            "status": "enabled"
+        }
+    }
 }
 ```
-- When the table/field is absent or status is not `enabled`, fallback is disabled (unreachable route present).
 
-### 7.4. CLI and Show Command Changes
+| Field | Allowed values | Default | Description |
+|---|---|---|---|
+| `status` | `enabled`, `disabled` | `disabled` | `enabled` permits legacy Linux RPDB fall-through; `disabled` installs the managed sentinel routes |
 
-#### 7.4.1. Configuration Commands
+- If the table, `GLOBAL` key, or `status` field is absent, the effective state is `disabled`.
+- `GLOBAL` is the only valid key in this table; the schema rejects additional keys.
+- Deleting the entry restores the default `disabled` state.
+- The CONFIG_DB schema rejects values other than `enabled` and `disabled`. As a defensive measure, `vrfmgrd` treats an unrecognized value as `disabled` and logs an error.
+- The CONFIG_DB schema and validation updates are in scope. No feature-specific configuration CLI or show command is defined.
 
-- Enable kernel VRF fallback (removes unreachable route from all non-default VRFs):
-    ```bash
-    config vrf kernel-vrf-fallback enable
-    ```
-- Disable (default, unreachable route present in all non-default VRFs):
-    ```bash
-    config vrf kernel-vrf-fallback disable
-    ```
-  or to restore default:
-    ```bash
-    config vrf kernel-vrf-fallback delete
-    ```
-  (This will remove the KERNEL_VRF_FALLBACK entry, restoring unreachable route.)
+### 7.4. APP_DB and Hardware Isolation
 
-#### 7.4.2. Show Command
+`vrfmgrd` installs the managed sentinel routes directly in the kernel and does not write them to APP_DB. Because FRR zebra may report kernel routes through FPM, `fpmsyncd` must inspect route type before any APP_DB operation and ignore both `RTM_NEWROUTE` and `RTM_DELROUTE` notifications whose route type is `RTN_UNREACHABLE`. Existing add-path filtering is retained; the delete path must provide the equivalent guard.
 
-- Show current fallback configuration:
-    ```bash
-    show vrf kernel-vrf-fallback
-    ```
-  **Sample Output:**
-    ```
-    Kernel VRF Fallback: Disabled
-    (Unreachable default route present in all non-default VRFs)
-    ```
-    or
-    ```
-    Kernel VRF Fallback: Enabled
-    (Unreachable default route NOT present; kernel fallback active)
-    ```
+Removal of a managed sentinel must not delete an APP_DB unicast default for the same prefix. Unit and integration tests must cover coexistence with a real IPv4 or IPv6 default route.
+
+No SAI object or ASIC route is created, changed, or removed by this feature.
 
 ### 7.5. Transition and Deprecation
 
-- The knob is a transitional setting, will be announced as deprecated, and removed in a future release.
+The global setting is a temporary compatibility mechanism. It will be documented as deprecated and removed in a future release. New deployments must not depend on Linux VRF fall-through.
+
+Before a warm or in-service rollback to software that does not implement this feature, the rollback procedure must remove the managed IPv4 and IPv6 sentinel routes from retained VRF tables and remove the persisted `KERNEL_VRF_FALLBACK|GLOBAL` entry. A cold rollback that deletes and recreates the VRF devices naturally removes their old routing tables, but the persisted CONFIG_DB entry must still be removed or migrated.
 
 ## 8. SAI API
 
-- **No SAI API changes required.**
-- Unreachable routes are kernel-only and not programmed in hardware.
+- **No SAI API changes are required.**
+- This feature does not create a SAI route, change `SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID`, or alter a SAI virtual-router fallback setting.
+- This HLD makes no platform-independent assertion that ASIC VRF fallback is present or absent. Existing hardware behavior is unchanged and outside the feature scope.
 
 ## 9. Configuration and Management
 
-### 9.1. CLI/YANG Model
+### 9.1. Persistent Configuration
 
-- See section 7.4 for updated config and show commands.
+The setting is supplied through the standard persistent CONFIG_DB workflow, such as a persistent configuration patch or `config_db.json`, and is loaded during normal CONFIG_DB initialization. A direct in-memory Redis write alone is not considered persistent configuration.
 
-### 9.2. CONFIG_DB Schema
+No feature-specific SONiC CLI, show command, or management API is introduced. Kernel state can be inspected with the existing Linux commands `ip route show vrf <VRF_NAME>` and `ip -6 route show vrf <VRF_NAME>`.
 
-- See section 7.3.
+### 9.2. Backward Compatibility
 
-### 9.3. Backward Compatibility
-
-- Default (knob unset): fallback disabled, matches ASIC.
-- Knob enabled: fallback restored (legacy only).
-- New deployments should not rely on kernel fallback feature.
+- Default, with the entry absent or `status=disabled`: legacy fall-through is disabled in the kernel route-lookup path; ASIC programming and hardware lookup behavior are unchanged.
+- Knob enabled: fallback is restored in the kernel forwarding path only. In this HLD, that means the Linux kernel route-lookup path for VRF-bound local output and software-forwarded packets. The managed sentinels are removed, permitting legacy RPDB fall-through when a later matching route exists; ASIC programming and hardware lookup behavior are unchanged.
+- Existing deployments that temporarily require the prior kernel behavior can persist `status=enabled` during migration.
+- New deployments must not rely on kernel VRF fallback.
 
 ## 10. Warmboot and Fastboot Design Impact
 
 ### 10.1. Warmboot Impact
 
-**No negative impact on warmboot functionality:**
-- Configuration persistence through CONFIG_DB
-- Route reconciliation during vrfmgrd restart
-- No additional stalls or IO operations in boot path
-- No changes to critical boot sequence
+- `vrfmgrd` reads the effective CONFIG_DB state before reconciling non-default VRFs.
+- Reconciliation is idempotent, so retained kernel state can be corrected after `vrfmgrd` restarts or warmboot completes.
+- The feature adds no APP_DB, ASIC_DB, SAI, or hardware replay state.
+- Kernel-routed reachability can change when the compatibility setting changes, as intended; hardware-forwarded traffic is unchanged.
 
 ### 10.2. Fastboot Impact
 
-**No impact on fastboot performance:**
-- Configuration loaded during normal service startup
-- No additional dependencies or processing overhead
-- Feature can be delayed without affecting critical services
+- The setting is loaded through the normal CONFIG_DB startup path.
+- `vrfmgrd` reconciles the applicable VRFs after their Linux devices and tables exist.
+- No additional hardware programming dependency is introduced.
 
 ### 10.3. Performance Analysis
 
-- **Boot Time**: No measurable impact on boot time
-- **CPU Usage**: Minimal CPU overhead during configuration changes only
-- **IO Operations**: Limited to route add/delete operations
-- **Critical Path**: Not in critical boot path
+- A steady-state VRF adds at most two kernel sentinel routes.
+- A global state transition performs at most two route operations per applicable VRF.
+- There is no ASIC route operation or hardware FIB impact.
 
 ## 11. Memory Consumption
 
-### 11.1. Memory Analysis
+- CONFIG_DB stores one small global entry only when the compatibility setting is explicitly present.
+- In the default `disabled` state, the Linux kernel stores one IPv4 and one IPv6 unreachable default per applicable non-default VRF.
+- Kernel route memory and transient reconciliation state scale linearly with the number of applicable VRFs.
+- The feature consumes no ASIC FIB resources.
 
-**Static Memory:**
-- Configuration storage in CONFIG_DB: ~100 bytes per VRF
-- Additional code in vrfmgrd: ~5KB
-
-**Dynamic Memory:**
-- No growing memory consumption during operation
-- Kernel route entries: ~64 bytes per unreachable route
-- No memory leaks or unbounded growth
-
-**Total Impact:**
-- Negligible memory footprint
-- No memory consumption when feature is disabled
-- Scales linearly with number of configured VRFs
-
-## 12. Restrictions/Limitations
+## 12. Restrictions and Limitations
 
 ### 12.1. Design Limitations
 
-- **L-1**: Unreachable routes affect only software-forwarded traffic
-- **L-2**: Feature requires Linux kernel support for unreachable routes
-- **L-3**: Does not modify BGP or other routing protocol behavior
-- **L-4**: Limited to VRF route lookup control, not general routing policy
+- **L-1**: The unreachable routes affect Linux route lookup, including VRF-bound locally generated traffic and packets forwarded in software. They do not affect packets forwarded entirely by the ASIC.
+- **L-2**: The setting is global and dual-stack; there is no per-VRF or per-address-family override.
+- **L-3**: Removing the sentinel routes only permits later RPDB lookup. It does not guarantee that a later rule or route provides reachability.
+- **L-4**: There is no BGP configuration or routing-protocol code change. The kernel route visibility and FPM filtering behavior remain subject to the tests in Section 13.
+- **L-5**: The design relies on `fpmsyncd` filtering `RTN_UNREACHABLE` additions and deletions before APP_DB mutation and preserving any coexisting unicast default route.
 
 ### 12.2. Platform Dependencies
 
-- **No platform-specific dependencies**
-- **Standard Linux iproute2 functionality required**
-- **Compatible with all SONiC-supported platforms**
+- Linux VRF and `l3mdev` RPDB support are required.
+- `iproute2` must support IPv4 and IPv6 unreachable routes in a VRF table.
+- Existing SAI and ASIC behavior is unchanged; no platform-specific SAI capability is required by this feature.
 
-### 12.3. Scale Limitations
+### 12.3. Scale Characteristics
 
-- **Limited by kernel route table capacity**
-- **Recommended maximum: 1000 VRFs (platform dependent)**
+- The default state adds two kernel routes per applicable non-default VRF.
+- Startup and global-state reconciliation are linear in the number of applicable VRFs.
 
-## 13. Testing Requirements/Design
-
-### 13.1. Unit Test Cases
-
-#### 13.1.1 CLI Tests
-- **UT-CLI-1**: Validate CLI command syntax and parameter validation
-- **UT-CLI-2**: Test CONFIG_DB updates for valid configurations
-- **UT-CLI-3**: Test error handling for invalid VRF names
-- **UT-CLI-4**: Test show command output formatting
-
-#### 13.1.2 CONFIG_DB Tests
-- **UT-DB-1**: Schema validation for global fallback entries
-- **UT-DB-2**: Schema validation for per-VRF fallback entries
-- **UT-DB-3**: Invalid configuration handling
-- **UT-DB-4**: Configuration persistence testing
-
-#### 13.1.3 VRF Manager Tests
-- **UT-MGR-1**: Configuration change monitoring
-- **UT-MGR-2**: Route addition/removal logic
-- **UT-MGR-3**: IPv4 and IPv6 handling independently
-- **UT-MGR-4**: Error handling for route operations
-
-### 13.2. System Test Cases
-
-#### 13.2.1 Functional Tests
-- **ST-FUNC-1**: Verify route fallback disabled with unreachable route present
-- **ST-FUNC-2**: Verify per-VRF override of global setting
-- **ST-FUNC-3**: Verify IPv4 and IPv6 independent operation
-- **ST-FUNC-4**: Test with multiple VRFs and mixed configurations
-
-#### 13.2.2 Integration Tests  
-- **ST-INT-1**: End-to-end CLI to kernel route verification
-- **ST-INT-2**: Configuration persistence across reboots
-- **ST-INT-3**: Config reload testing
-- **ST-INT-4**: Warm reboot with feature enabled
-
-#### 13.2.3 Upgrade/Downgrade Tests
-- **ST-UPG-1**: Seamless upgrade from pre-feature version
-- **ST-UPG-2**: Configuration migration validation
-- **ST-UPG-3**: Graceful downgrade with cleanup
-- **ST-UPG-4**: Schema validation across versions
-
-#### 13.2.4 Performance Tests
-- **ST-PERF-1**: Boot time impact measurement
-- **ST-PERF-2**: Memory consumption validation
-- **ST-PERF-3**: Route operation performance
-- **ST-PERF-4**: Scale testing with multiple VRFs
-
-#### 13.2.5 Negative Tests
-- **ST-NEG-1**: Invalid configuration handling
-- **ST-NEG-2**: Non-existent VRF handling
-- **ST-NEG-3**: Kernel route operation failures
-- **ST-NEG-4**: Configuration corruption recovery
-
-### 13.3. Warmboot/Fastboot Testing
-
-- **Verify no impact on existing warmboot/fastboot timings**
-- **Confirm zero data plane disruption during configuration changes**
-- **Test route reconciliation after warmboot**
-- **Validate configuration persistence across boot cycles**
-## 13. Testing Requirements/Design
+## 13. Testing Requirements and Design
 
 ### 13.1. Unit Tests
 
-- **UT-CLI-1**: Validate new CLI commands.
-- **UT-DB-1**: Schema validation for KERNEL_VRF_FALLBACK.
-- **UT-MGR-1**: Ensure unreachable route is added/removed on knob change.
+#### 13.1.1. CONFIG_DB Tests
+
+- **UT-DB-1**: Validate `KERNEL_VRF_FALLBACK|GLOBAL` with `status=enabled` and `status=disabled`.
+- **UT-DB-2**: Reject an invalid `status` value and a malformed entry.
+- **UT-DB-3**: Verify that an absent or deleted entry produces the default `disabled` state.
+- **UT-DB-4**: Verify serialization and reload of the persistent global entry.
+
+#### 13.1.2. VRF Manager Tests
+
+- **UT-MGR-1**: Verify that startup reads the global state before reconciling existing VRFs.
+- **UT-MGR-2**: Verify IPv4 and IPv6 route replacement when the state is absent or `disabled`.
+- **UT-MGR-3**: Verify exact route deletion when the state changes to `enabled` and that a VRF created while enabled receives no sentinel route.
+- **UT-MGR-4**: Verify that entry deletion restores both routes in every existing applicable VRF.
+- **UT-MGR-5**: Verify idempotent replacement, tolerant deletion of an already-absent route, and recovery after a route-operation failure.
+- **UT-MGR-6**: Verify that specialized VRF-like objects outside the `vrfmgrd` lifecycle retain their existing behavior.
+
+#### 13.1.3. FPM and RouteSync Tests
+
+- **UT-FPM-1**: Verify that IPv4 and IPv6 `RTN_UNREACHABLE` add and delete notifications are ignored before APP_DB mutation.
+- **UT-FPM-2**: Verify that deleting a managed sentinel does not delete a coexisting APP_DB unicast default.
+- **UT-FPM-3**: Verify that no ASIC_DB or SAI route operation is generated for the sentinel routes.
 
 ### 13.2. System Tests
 
-- **ST-FUNC-1**: Confirm fallback is disabled by default (unreachable route present).
-- **ST-FUNC-2**: Confirm fallback is enabled when knob set (unreachable route absent).
-- **ST-FUNC-3**: Confirm correct behavior after config reload/warmboot.
+#### 13.2.1. Functional Tests
 
-## 14. Open/Action Items
+- **ST-FUNC-1**: With the entry absent, verify that both sentinel routes are present and an otherwise-unmatched Linux VRF lookup is terminal.
+- **ST-FUNC-2**: With `status=enabled`, verify that both sentinel routes are absent and RPDB fall-through is permitted; verify successful fallback only when a later matching route exists.
+- **ST-FUNC-3**: Verify the same global behavior for IPv4 and IPv6 across multiple non-default VRFs.
+- **ST-FUNC-4**: Verify that more-specific routes and real default routes with a lower metric take precedence over the sentinel routes.
+- **ST-FUNC-5**: Verify both VRF-bound locally originated traffic and packets forwarded in software.
 
-- Implementation and deprecation notice for knob in docs.
-- CLI and show command updates.
+#### 13.2.2. Integration Tests
+
+- **ST-INT-1**: Verify the end-to-end CONFIG_DB-to-kernel path for enable, disable, and entry deletion.
+- **ST-INT-2**: Verify that no sentinel route appears in APP_DB or ASIC_DB and that hardware forwarding state is unchanged.
+- **ST-INT-3**: Verify coexistence with a real IPv4 and IPv6 default route while toggling the setting.
+- **ST-INT-4**: Verify a new VRF created while enabled, a VRF deleted during reconciliation, and multiple existing VRFs during a global transition.
+- **ST-INT-5**: Verify behavior after `vrfmgrd` restart, configuration reload, warmboot, and fastboot.
+
+#### 13.2.3. Upgrade and Downgrade Tests
+
+- **ST-UPG-1**: Upgrade with no compatibility entry and verify installation of the default sentinel routes.
+- **ST-UPG-2**: Upgrade with `status=enabled` and verify preservation of the legacy kernel behavior.
+- **ST-UPG-3**: Verify explicit sentinel and persisted CONFIG_DB-entry cleanup during a warm or in-service downgrade.
+- **ST-UPG-4**: Verify that a cold downgrade that recreates VRF devices leaves no stale sentinel route or unsupported CONFIG_DB entry.
+- **ST-UPG-5**: Verify adoption of an exact pre-existing sentinel when the feature starts in the default `disabled` state.
+
+#### 13.2.4. Performance and Scale Tests
+
+- **ST-PERF-1**: Measure startup and reconciliation time with the platform's supported VRF scale.
+- **ST-PERF-2**: Validate linear kernel route and memory growth.
+- **ST-PERF-3**: Confirm that no ASIC route operations are generated during reconciliation.
+
+#### 13.2.5. Negative Tests
+
+- **ST-NEG-1**: Reject invalid CONFIG_DB values and malformed entries.
+- **ST-NEG-2**: Verify convergence when VRFs are created or deleted during global-state reconciliation.
+- **ST-NEG-3**: Inject kernel route-operation failures and verify error reporting and later reconciliation.
+- **ST-NEG-4**: Verify that toggling the setting preserves every route that does not exactly match the managed sentinel identity, including a unicast default route.
+
+### 13.3. Warmboot and Fastboot Testing
+
+- Verify persistence of an explicit `enabled` or `disabled` state across boot cycles.
+- Verify kernel route reconciliation after warmboot and service restart.
+- Confirm that the sentinel routes remain absent from APP_DB and ASIC_DB after reconciliation.
+- Confirm that configuration changes affect only kernel-routed traffic and do not disrupt ASIC or hardware forwarding.
+
+## 14. Open and Action Items
+
+- Implement the CONFIG_DB schema and `vrfmgrd` handling for the temporary compatibility setting.
+- Add regression coverage for `fpmsyncd` filtering and preservation of coexisting unicast default routes.
+- Document the compatibility setting's deprecation, persistent configuration path, and rollback cleanup procedure.

--- a/doc/vrf/no-default-vrf-route-fallback-hld.md
+++ b/doc/vrf/no-default-vrf-route-fallback-hld.md
@@ -25,6 +25,7 @@
 | 2.0 | 2025-09-09 | Sudharsan Rajagopalan | Added default unreachable routes and the global fallback knob |
 | 3.0 | 2026-07-02 | Sudharsan Rajagopalan | Clarified the kernel-only scope and CONFIG_DB-only management; removed the CLI design |
 | 3.1 | 2026-07-02 | Sudharsan Rajagopalan | Clarified the Linux and prior downstream defaults, the intentional upstream default change, and upgrade mapping |
+| 3.2 | 2026-07-02 | Sudharsan Rajagopalan | Clarified namespace-local multi-ASIC persistence, applicable VRFs, and rollback ordering |
 
 ## 2. Scope
 
@@ -76,12 +77,12 @@ The unreachable defaults are installed directly in the Linux kernel. FRR may obs
 ### 5.1. Functional Requirements
 
 - **FR-1**: When kernel fallback is not enabled, ensure that managed IPv4 and IPv6 unreachable default routes with metric `4278198272` are present in every applicable non-default Linux VRF table.
-- **FR-2**: Provide one global CONFIG_DB setting that controls both IPv4 and IPv6 behavior for all applicable non-default VRFs.
+- **FR-2**: Provide one logical global CONFIG_DB setting that controls both IPv4 and IPv6 behavior for all applicable non-default VRFs. Each `vrfmgrd` consumes its namespace-local copy; a multi-ASIC system persists the same value in every applicable data-ASIC CONFIG_DB.
 - **FR-3**: When `status` is `enabled`, remove only the managed sentinel routes from existing non-default VRFs and do not add them to newly created non-default VRFs.
 - **FR-4**: When `status` is `disabled`, the CONFIG_DB entry is deleted, or the entry is absent, ensure that the managed sentinel routes are present in existing and newly created non-default VRFs.
 - **FR-5**: Read the effective global state before processing VRF creation events and reconcile all existing non-default VRFs at startup, after a configuration change, and after `vrfmgrd` restarts.
 - **FR-6**: Keep the managed sentinel routes out of APP_DB, ASIC_DB, SAI, and the hardware FIB. `fpmsyncd` must ignore their add and delete notifications before mutating APP_DB, so removing a sentinel cannot remove or alter a real unicast default route.
-- **FR-7**: Preserve an explicitly configured compatibility setting across reboot and configuration reload through the standard persistent CONFIG_DB workflow.
+- **FR-7**: Preserve an explicitly configured compatibility setting across reboot and configuration reload through the standard persistent CONFIG_DB workflow, including every applicable data-ASIC namespace on a multi-ASIC system.
 - **FR-8**: Deprecate and remove the compatibility setting in a future release.
 
 ### 5.2. Non-Functional Requirements
@@ -92,15 +93,15 @@ The unreachable defaults are installed directly in the Linux kernel. FRR may obs
 
 ### 5.3. Exemptions and Limitations
 
-- **EX-1**: The setting is global; there is no per-VRF override.
+- **EX-1**: The setting is logically device-global; there is no per-VRF override. Multi-ASIC CONFIG_DB storage is namespace-local, so the persistent configuration must supply the same value to every applicable data-ASIC namespace.
 - **EX-2**: One setting controls both IPv4 and IPv6; the address families cannot be configured independently.
 - **EX-3**: A feature-specific CLI, show command, and management API are outside the scope of this HLD.
 - **EX-4**: SAI and hardware fallback behavior are outside the scope of this HLD.
-- **EX-5**: The feature applies to non-default Linux VRFs managed through the `vrfmgrd` lifecycle. Specialized VRF-like objects outside that lifecycle retain their existing handling.
+- **EX-5**: The feature applies to regular VRF and VNET Linux VRF devices managed through the `vrfmgrd` lifecycle. The management VRF device, which is created by `hostcfgd`, and specialized VRF-like objects outside that lifecycle retain their existing handling.
 
 ## 6. Architecture Design
 
-- **CONFIG_DB** stores the global compatibility setting.
+- **CONFIG_DB** stores the logical global compatibility setting. On multi-ASIC systems, each applicable data-ASIC CONFIG_DB stores an identical namespace-local copy.
 - **VRF Manager (`vrfmgrd`)** caches the effective setting and reconciles managed sentinel routes in the applicable Linux VRF tables.
 - **Linux Kernel** performs the affected route lookup and maintains the unreachable route entries.
 - **FRR zebra and `fpmsyncd`** may observe kernel route notifications. `fpmsyncd` filters `RTN_UNREACHABLE` additions and deletions before they can change APP_DB or the hardware programming pipeline.
@@ -181,6 +182,7 @@ For a VRF created while `status=enabled`, `vrfmgrd` does not add either managed 
 - `GLOBAL` is the only valid key in this table; the schema rejects additional keys.
 - Deleting the entry restores the default `disabled` state.
 - The CONFIG_DB schema rejects values other than `enabled` and `disabled`. As a defensive measure, `vrfmgrd` treats an unrecognized value as `disabled` and logs an error.
+- `GLOBAL` is a singleton row key, not a cross-namespace replication mechanism. On a multi-ASIC system, each `vrfmgrd` reads its namespace-local CONFIG_DB. The persistent configuration must place the same row and value in every applicable data-ASIC namespace; a host-only or `localhost` row does not control per-ASIC VRFs. If one namespace omits the row, that namespace uses the default `disabled` state.
 - The CONFIG_DB schema and validation updates are in scope. No feature-specific configuration CLI or show command is defined.
 
 ### 7.4. APP_DB and Hardware Isolation
@@ -195,7 +197,7 @@ No SAI object or ASIC route is created, changed, or removed by this feature.
 
 The global setting is a temporary compatibility mechanism. It will be documented as deprecated and removed in a future release. New deployments must not depend on Linux VRF fall-through.
 
-Before a warm or in-service rollback to software that does not implement this feature, the rollback procedure must remove the managed IPv4 and IPv6 sentinel routes from retained VRF tables and remove the persisted `KERNEL_VRF_FALLBACK|GLOBAL` entry. A cold rollback that deletes and recreates the VRF devices naturally removes their old routing tables, but the persisted CONFIG_DB entry must still be removed or migrated.
+Before a warm or in-service rollback to software that does not implement this feature, persist `status=enabled`, allow the current `vrfmgrd` instances to reconcile, and verify that both sentinels are absent from every retained applicable VRF. Then stop or quiesce the current `vrfmgrd` instances so they cannot consume another CONFIG_DB update, remove every persisted namespace copy of `KERNEL_VRF_FALLBACK|GLOBAL`, verify or manually clean up the exact routes, and only then start the older software. Deleting the row while the current daemon is running would restore the default `disabled` state and reinstall the sentinels. A cold rollback that deletes and recreates the VRF devices naturally removes their old routing tables, but every persisted CONFIG_DB copy must still be removed or migrated.
 
 ## 8. SAI API
 
@@ -208,6 +210,8 @@ Before a warm or in-service rollback to software that does not implement this fe
 ### 9.1. Persistent Configuration
 
 The setting is supplied through the standard persistent CONFIG_DB workflow, such as a persistent configuration patch or `config_db.json`, and is loaded during normal CONFIG_DB initialization. A direct in-memory Redis write alone is not considered persistent configuration.
+
+On a multi-ASIC system, CONFIG_DB and `vrfmgrd` are namespace-local. The standard single-file or patch workflow must explicitly persist an identical `KERNEL_VRF_FALLBACK|GLOBAL` row under every applicable `asicN` scope. A copy under only `localhost` does not reach the per-ASIC daemons, and the infrastructure does not automatically replicate or enforce consistency between scoped copies. The absent/default `disabled` state needs no row; preserving compatibility requires `status=enabled` in every applicable data-ASIC namespace.
 
 No feature-specific SONiC CLI, show command, or management API is introduced. Kernel state can be inspected with the existing Linux commands `ip route show vrf <VRF_NAME>` and `ip -6 route show vrf <VRF_NAME>`.
 
@@ -241,7 +245,7 @@ No feature-specific SONiC CLI, show command, or management API is introduced. Ke
 
 ## 11. Memory Consumption
 
-- CONFIG_DB stores one small global entry only when the compatibility setting is explicitly present.
+- CONFIG_DB stores one small entry only when the compatibility setting is explicitly present: one entry on a single-ASIC system or one identical entry per applicable data-ASIC namespace on a multi-ASIC system.
 - In the default `disabled` state, the Linux kernel stores one IPv4 and one IPv6 unreachable default per applicable non-default VRF.
 - Kernel route memory and transient reconciliation state scale linearly with the number of applicable VRFs.
 - The feature consumes no ASIC FIB resources.
@@ -255,6 +259,7 @@ No feature-specific SONiC CLI, show command, or management API is introduced. Ke
 - **L-3**: Removing the sentinel routes only permits later RPDB lookup. It does not guarantee that a later rule or route provides reachability.
 - **L-4**: There is no BGP configuration or routing-protocol code change. The kernel route visibility and FPM filtering behavior remain subject to the tests in Section 13.
 - **L-5**: The design relies on `fpmsyncd` filtering `RTN_UNREACHABLE` additions and deletions before APP_DB mutation and preserving any coexisting unicast default route.
+- **L-6**: Multi-ASIC CONFIG_DB persistence does not automatically replicate or enforce equality of the namespace-local copies. Configuration tooling or the operator must provide the same value to every applicable data-ASIC namespace.
 
 ### 12.2. Platform Dependencies
 
@@ -277,6 +282,7 @@ No feature-specific SONiC CLI, show command, or management API is introduced. Ke
 - **UT-DB-2**: Reject an invalid `status` value and a malformed entry.
 - **UT-DB-3**: Verify that an absent or deleted entry produces the default `disabled` state.
 - **UT-DB-4**: Verify serialization and reload of the persistent global entry.
+- **UT-DB-5**: On multi-ASIC systems, verify that each data-ASIC namespace is validated and persisted independently, and that a host-only entry is not treated as a per-ASIC setting.
 
 #### 13.1.2. VRF Manager Tests
 
@@ -310,6 +316,7 @@ No feature-specific SONiC CLI, show command, or management API is introduced. Ke
 - **ST-INT-3**: Verify coexistence with a real IPv4 and IPv6 default route while toggling the setting.
 - **ST-INT-4**: Verify a new VRF created while enabled, a VRF deleted during reconciliation, and multiple existing VRFs during a global transition.
 - **ST-INT-5**: Verify behavior after `vrfmgrd` restart, configuration reload, warmboot, and fastboot.
+- **ST-INT-6**: On a multi-ASIC system, verify identical explicit values across all applicable data-ASIC namespaces, host-only entry isolation, default `disabled` behavior when one namespace omits the row, and save/reload persistence of every scoped copy.
 
 #### 13.2.3. Upgrade and Downgrade Tests
 

--- a/doc/vrf/no-default-vrf-route-fallback-hld.md
+++ b/doc/vrf/no-default-vrf-route-fallback-hld.md
@@ -24,6 +24,7 @@
 | 1.0 | 2025-09-04 | Sudharsan Rajagopalan | Initial draft for VRF route fallback control |
 | 2.0 | 2025-09-09 | Sudharsan Rajagopalan | Added default unreachable routes and the global fallback knob |
 | 3.0 | 2026-07-02 | Sudharsan Rajagopalan | Clarified the kernel-only scope and CONFIG_DB-only management; removed the CLI design |
+| 3.1 | 2026-07-02 | Sudharsan Rajagopalan | Clarified the Linux and prior downstream defaults, the intentional upstream default change, and upgrade mapping |
 
 ## 2. Scope
 
@@ -49,11 +50,24 @@ This HLD changes only Linux VRF route lookup for traffic processed by the host k
 
 ## 4. Overview
 
-Linux VRF devices use an `l3mdev` RPDB rule to select the routing table associated with the VRF. If that table has no matching route, lookup can continue to later RPDB rules and routing tables, including the default routing table. This legacy behavior can allow kernel-routed traffic to leave the intended VRF.
+Linux VRF devices use an `l3mdev` RPDB rule to select the routing table associated with the VRF. By default, vanilla Linux permits an unmatched lookup in that table to continue to later RPDB rules and routing tables, including the default routing table. This legacy fall-through can allow kernel-routed traffic to leave the intended VRF.
 
 The [Linux VRF documentation](https://docs.kernel.org/networking/vrf.html) recommends an unreachable default route with metric `4278198272`. The route makes an otherwise-unmatched lookup terminal while allowing more-specific routes, or a usable default route with a lower metric, to take precedence. FRR interprets the metric as administrative distance and priority `[255/8192]`.
 
+[sonic-swss PR #2943](https://github.com/sonic-net/sonic-swss/pull/2943) documents the same IPv4 kernel behavior and prototypes the mitigation by programming an unreachable default route when a VRF is created. PR #2943 is an IPv4-only, non-normative prototype; this HLD independently specifies managed IPv4 and IPv6 behavior.
+
 This feature changes Linux route lookup only. It neither enables nor disables fallback in an ASIC. Hardware behavior remains unchanged and is determined by the platform's existing SAI and ASIC implementation. On platforms whose hardware already terminates a route miss within the selected virtual router, this feature aligns the Linux route-miss result with that behavior.
+
+The historical defaults and the new compatibility setting must not be conflated:
+
+| Context | Default or control state | Unreachable sentinel | Effective Linux behavior |
+|---|---|---|---|
+| Vanilla Linux and SONiC deployments without sentinel routes | No fallback-suppression feature | Absent | RPDB fall-through is permitted |
+| Prior downstream implementation | Disable-fallback control is false or absent | Absent | RPDB fall-through is permitted |
+| This upstream design | `KERNEL_VRF_FALLBACK|GLOBAL` is absent or `status=disabled` | Present | RPDB fall-through is blocked |
+| This upstream compatibility mode | `KERNEL_VRF_FALLBACK|GLOBAL` with `status=enabled` | Absent | RPDB fall-through is permitted |
+
+The upstream default change is intentional: it aligns the kernel route-miss result on platforms whose existing ASIC behavior terminates a VRF miss, without changing ASIC programming. The prior downstream disable control blocked fallback when asserted, whereas the new temporary compatibility state restores fallback only when `status=enabled`. This HLD does not provide automatic conversion of a prior downstream control; any operator- or platform-provided migration must map the intended effective behavior rather than copy a disable-control boolean literally.
 
 The unreachable defaults are installed directly in the Linux kernel. FRR may observe kernel route notifications, so `fpmsyncd` must filter both add and delete notifications for `RTN_UNREACHABLE` routes before changing APP_DB. Consequently, the managed sentinel routes are not translated into ASIC_DB or SAI route objects and do not consume hardware FIB resources.
 
@@ -114,7 +128,7 @@ CONFIG_DB (KERNEL_VRF_FALLBACK|GLOBAL)
 
 ### 7.1. Effective State
 
-The default effective state is `disabled`, meaning that legacy Linux RPDB fall-through is disabled. Only the explicit value `enabled` selects the compatibility behavior.
+The upstream default effective state of the new compatibility setting is `disabled`, meaning that legacy Linux RPDB fall-through is disabled. This is an intentional change from vanilla Linux, SONiC deployments without sentinel routes, and a false or absent prior downstream disable-fallback control. Only the explicit value `enabled` temporarily restores the prior behavior.
 
 | CONFIG_DB state | `vrfmgrd` action | Linux route-lookup result | Hardware result |
 |---|---|---|---|
@@ -199,9 +213,9 @@ No feature-specific SONiC CLI, show command, or management API is introduced. Ke
 
 ### 9.2. Backward Compatibility
 
-- Default, with the entry absent or `status=disabled`: legacy fall-through is disabled in the kernel route-lookup path; ASIC programming and hardware lookup behavior are unchanged.
-- Knob enabled: fallback is restored in the kernel forwarding path only. In this HLD, that means the Linux kernel route-lookup path for VRF-bound local output and software-forwarded packets. The managed sentinels are removed, permitting legacy RPDB fall-through when a later matching route exists; ASIC programming and hardware lookup behavior are unchanged.
-- Existing deployments that temporarily require the prior kernel behavior can persist `status=enabled` during migration.
+- An upgrade from a fallback-allowed SONiC deployment or from the prior downstream false or absent disable-control state changes the effective kernel behavior when the new entry is absent: `vrfmgrd` installs the sentinels and disables legacy fall-through. This is the intentional upstream default; ASIC programming and hardware lookup behavior are unchanged.
+- This HLD provides no automatic conversion of a prior downstream configuration. If uninterrupted legacy fallback is required, `status=enabled` must be persisted before the new `vrfmgrd` starts reconciliation. The managed sentinels are then kept absent, permitting legacy RPDB fall-through for VRF-bound local output and software-forwarded packets when a later matching route exists; ASIC programming and hardware lookup behavior remain unchanged.
+- Any operator- or platform-provided migration from a prior disable-fallback control must map effective behavior rather than copy the old boolean literally. An inactive or absent prior disable control, which allowed fallback, maps to `status=enabled` only when preserving that behavior is required. An active prior disable control, which blocked fallback, maps to the new absent or `status=disabled` state.
 - New deployments must not rely on kernel VRF fallback.
 
 ## 10. Warmboot and Fastboot Design Impact
@@ -284,7 +298,7 @@ No feature-specific SONiC CLI, show command, or management API is introduced. Ke
 #### 13.2.1. Functional Tests
 
 - **ST-FUNC-1**: With the entry absent, verify that both sentinel routes are present and an otherwise-unmatched Linux VRF lookup is terminal.
-- **ST-FUNC-2**: With `status=enabled`, verify that both sentinel routes are absent and RPDB fall-through is permitted; verify successful fallback only when a later matching route exists.
+- **ST-FUNC-2**: With the temporary compatibility state `status=enabled`, verify that both sentinel routes are absent and RPDB fall-through is permitted; verify successful fallback only when a later matching route exists.
 - **ST-FUNC-3**: Verify the same global behavior for IPv4 and IPv6 across multiple non-default VRFs.
 - **ST-FUNC-4**: Verify that more-specific routes and real default routes with a lower metric take precedence over the sentinel routes.
 - **ST-FUNC-5**: Verify both VRF-bound locally originated traffic and packets forwarded in software.
@@ -299,11 +313,12 @@ No feature-specific SONiC CLI, show command, or management API is introduced. Ke
 
 #### 13.2.3. Upgrade and Downgrade Tests
 
-- **ST-UPG-1**: Upgrade with no compatibility entry and verify installation of the default sentinel routes.
-- **ST-UPG-2**: Upgrade with `status=enabled` and verify preservation of the legacy kernel behavior.
+- **ST-UPG-1**: Upgrade from a fallback-allowed SONiC deployment or a false or absent downstream disable-fallback control with no new compatibility entry; verify the intentional change from vanilla Linux behavior to the upstream default by confirming that both sentinel routes are installed and legacy fall-through is blocked.
+- **ST-UPG-2**: Upgrade from a fallback-allowed state with `status=enabled` persisted before the new `vrfmgrd` starts reconciliation; verify uninterrupted preservation of the legacy kernel behavior.
 - **ST-UPG-3**: Verify explicit sentinel and persisted CONFIG_DB-entry cleanup during a warm or in-service downgrade.
 - **ST-UPG-4**: Verify that a cold downgrade that recreates VRF devices leaves no stale sentinel route or unsupported CONFIG_DB entry.
 - **ST-UPG-5**: Verify adoption of an exact pre-existing sentinel when the feature starts in the default `disabled` state.
+- **ST-UPG-6**: Where operator- or platform-provided migration tooling translates a prior disable-fallback control, verify behavior-based mapping: inactive or absent maps to `status=enabled` only when legacy fallback must be preserved, while active maps to the new absent or `status=disabled` state. Verify that no automatic upstream conversion is assumed.
 
 #### 13.2.4. Performance and Scale Tests
 


### PR DESCRIPTION
This document provides the high-level design for Linux VRF Route Lookup Fallback Control. By default, `vrfmgrd` blocks legacy Linux RPDB fall-through in applicable non-default VRFs, aligning the kernel route-miss result with ASICs that terminate a VRF miss. An explicit global compatibility setting can temporarily restore legacy kernel fallback. The feature changes Linux kernel routing only; SAI and ASIC programming remain unchanged.