### PR TITLE
Check mirror ingress/egress capability before configuring it or setting it to SAI

### DIFF
--- a/doc/port-mirroring/SONiC_Port_Mirroring_HLD.md
+++ b/doc/port-mirroring/SONiC_Port_Mirroring_HLD.md
@@ -629,14 +629,13 @@ The following test cases validate the mirror capability discovery and validation
 
 | S.No | Test Case Synopsis |
 |------|-------------------|
-| 20 | Verify that CLI validates mirror direction capabilities before configuration |
+| 20 | Verify that capability checking fails when direction is not supported |
 | 21 | Verify that CLI returns appropriate error messages for unsupported directions |
 | 22 | Verify that CLI allows configuration when capabilities are supported |
-| 23 | Verify that CLI capability checking works for both SPAN and ERSPAN sessions |
-| 24 | Verify that CLI capability checking is not performed when no direction is specified |
 
-### 9.2.2 Integration Tests
+### 9.2.2 Swss Mock Tests
 
 | S.No | Test Case Synopsis |
 |------|-------------------|
-| 25 | Verify end-to-end capability validation from CLI to SAI |
+| 25 | Verify that capability checking fails when direction is not supported |
+| 26 | Verify that the mirror capability is inserted into the STATE_DB |


### PR DESCRIPTION
Check mirror capability before configuring it or setting it to SAI
1. Switch orchagent fetches the mirror capabilities from SAI during initialization and exposes to field `PORT_INGRESS_MIRROR_CAPABLE` and `PORT_EGRESS_MIRROR_CAPABLE` in `STATE_DB` table `SWITCH_CAPABILITY`.
2. Mirror orchagent check whether the direction is supported before calling the corresponding SAI API.
3. CLI checks the capability in `PORT_INGRESS_MIRROR_CAPABLE` and `PORT_EGRESS_MIRROR_CAPABLE` in `STATE_DB` table `SWITCH_CAPABILITY` before conifiguring CONFIG_DB

Implementation PRs
| Module | PR title | state |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| sonic-swss | [Support checking capabilities of the mirror](https://github.com/sonic-net/sonic-swss/pull/3934) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-swss/3934) |
| sonic-utilities | [Fetch capability of mirror before configuring it](https://github.com/sonic-net/sonic-utilities/pull/4089) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-utilities/4089) |


Signed-off-by: Stephen Sun <stephens@nvidia.com>