### PR TITLE
Fix external image reference in flow counters documentation

### DIFF
--- a/doc/flow_counters/flow_counters.md
+++ b/doc/flow_counters/flow_counters.md
@@ -72,7 +72,7 @@ Flow counter shall utilize the following existing infrastructure:
 
 The following describes the configuration and flows for host interface traps counter:
 
-![architecture](https://github.com/Junchao-Mellanox/SONiC/blob/flow-counter/doc/flow_counters/architecture.png)
+![architecture](architecture.png)
 
 (1) Customer uses the counterpoll CLI to enable/disable Flex Counters for Trap Flow Counter. If needed the default polling interval can be changed. The Flex Counter Orch Agent should be extended to support the Trap group. Configuration is pushed into CFG_FLEX_COUNTER_TABLE in CONFIG DB
 


### PR DESCRIPTION
This PR updates the image reference in flow counters documentation to use a relative path, following the same pattern as commit 9c620d6.

**Changes:**
- Update image reference in `flow_counters.md` to use relative path instead of Junchao-Mellanox fork URL
- Image already exists locally in `doc/flow_counters/`

This improves maintainability and ensures images are kept together with their documentation.