### PR TITLE
Fix markdownlint issues in Syslog Design doc

### DIFF
--- a/doc/syslog/syslog-design.md
+++ b/doc/syslog/syslog-design.md
@@ -5,57 +5,66 @@
 
 ## Table of contents
 
-- [1. Introduction](#1-introduction)
-  - [1.1. Feature overview](#11-feature-overview)
-  - [1.2. Requirements](#12-requirements)
-    - [1.2.1. Functionality](#121-functionality)
-    - [1.2.2. Command interface](#122-command-interface)
-    - [1.2.3. Error handling](#123-error-handling)
-    - [1.2.4. Event logging](#124-event-logging)
-      - [1.2.4.1. Table 1: Event logging](#1241-table-1-event-logging)
-- [2. Design](#2-design)
-  - [2.1. Overview](#21-overview)
-  - [2.2. Syslog Forwarding Output Module](#22-syslog-forwarding-output-module)
+- [SONiC Syslog Source IP](#sonic-syslog-source-ip)
+  - [High Level Design document](#high-level-design-document)
+  - [Table of contents](#table-of-contents)
+  - [Revision](#revision)
+  - [About this manual](#about-this-manual)
+  - [Scope](#scope)
+  - [Abbreviations](#abbreviations)
+  - [List of figures](#list-of-figures)
+  - [List of tables](#list-of-tables)
+  - [1. Introduction](#1-introduction)
+    - [1.1. Feature overview](#11-feature-overview)
+    - [1.2. Requirements](#12-requirements)
+      - [1.2.1. Functionality](#121-functionality)
+      - [1.2.2. Command interface](#122-command-interface)
+      - [1.2.3. Error handling](#123-error-handling)
+      - [1.2.4. Event logging](#124-event-logging)
+        - [1.2.4.1. Table 1: Event logging](#1241-table-1-event-logging)
+  - [2. Design](#2-design)
+    - [2.1. Overview](#21-overview)
+    - [2.2. Syslog Forwarding Output Module](#22-syslog-forwarding-output-module)
     - [2.2.1. Overview](#221-overview)
       - [2.2.1.1. Table 2: Syslog global config Module](#2211-table-2-syslog-global-config-module)
       - [2.2.1.2. Table 3: Syslog Forwarding Output Module](#2212-table-3-syslog-forwarding-output-module)
-    - [2.2.2. IpFreeBind](#222-ipfreebind)
-  - [2.3. Configuration agent](#23-configuration-agent)
-    - [2.3.1. Overview](#231-overview)
-    - [2.3.2. global syslog configuration](#232-global-syslog-configuration)
-      - [2.3.2.1. Table 4: Global configuration parameters](#2321-table-4-global-configuration-parameters)
-      - [2.3.2.2. Format: `set`:](#2322-format-set)
-    - [2.3.3. SSIP parameters](#233-ssip-parameters)
-      - [2.3.3.1. Table 5: SSIP parameters](#2331-table-5-ssip-parameters)
-    - [2.3.4. SSIP configuration](#234-ssip-configuration)
-      - [2.3.4.1. VRF/Source: `unset/unset`](#2341-vrfsource-unsetunset)
-      - [2.3.4.2. VRF/Source: `unset/set`](#2342-vrfsource-unsetset)
-      - [2.3.4.3. VRF/Source: `set/unset`](#2343-vrfsource-setunset)
-      - [2.3.4.4. VRF/Source: `set/set`](#2344-vrfsource-setset)
-      - [2.3.4.5. Filter/Severity: `set/set`](#2345-filterseverity-setset)
-      - [2.3.4.6. Protocol: `set`](#2346-protocol-set)
-  - [2.4. DB schema](#24-db-schema)
-    - [2.4.1. Config DB](#241-config-db)
-      - [2.4.1.1. Global syslog table](#2411-global-syslog-table)
-      - [2.4.1.2. SSIP table](#2412-ssip-table)
-    - [2.4.2. Data sample](#242-data-sample)
-    - [2.4.3. Configuration sample](#243-configuration-sample)
-    - [2.4.4. Configuration migration](#244-configuration-migration)
-  - [2.5. Flows](#25-flows)
-    - [2.5.1. SSIP add](#251-ssip-add)
-      - [2.5.1.1. Figure 1: SSIP add flow](#2511-figure-1-ssip-add-flow)
-    - [2.5.2. SSIP remove](#252-ssip-remove)
-      - [2.5.2.1. Figure 2: SSIP remove flow](#2521-figure-2-ssip-remove-flow)
-  - [2.6. CLI](#26-cli)
-    - [2.6.1. Command structure](#261-command-structure)
-    - [2.6.2. Usage examples](#262-usage-examples)
-      - [2.6.2.1. Config command group](#2621-config-command-group)
-      - [2.6.2.2. Show command group](#2622-show-command-group)
-  - [2.7. YANG model](#27-yang-model)
-  - [2.8. Warm/Fast boot](#28-warmfast-boot)
-- [3. Test plan](#3-test-plan)
-  - [3.1. Unit tests via VS](#31-unit-tests-via-vs)
-  - [3.2. Data plane tests via PTF](#32-data-plane-tests-via-ptf)
+      - [2.2.2. IpFreeBind](#222-ipfreebind)
+    - [2.3. Configuration agent](#23-configuration-agent)
+      - [2.3.1. Overview](#231-overview)
+      - [2.3.2. global syslog configuration](#232-global-syslog-configuration)
+        - [2.3.2.1. Table 4: Global configuration parameters](#2321-table-4-global-configuration-parameters)
+        - [2.3.2.2. Format: `set`](#2322-format-set)
+      - [2.3.3. SSIP parameters](#233-ssip-parameters)
+        - [2.3.3.1. Table 5: SSIP parameters](#2331-table-5-ssip-parameters)
+      - [2.3.4. SSIP configuration](#234-ssip-configuration)
+        - [2.3.4.1. VRF/Source: `unset/unset`](#2341-vrfsource-unsetunset)
+        - [2.3.4.2. VRF/Source: `unset/set`](#2342-vrfsource-unsetset)
+        - [2.3.4.3. VRF/Source: `set/unset`](#2343-vrfsource-setunset)
+        - [2.3.4.4. VRF/Source: `set/set`](#2344-vrfsource-setset)
+        - [2.3.4.5. Filter/Severity: `set/set`](#2345-filterseverity-setset)
+        - [2.3.4.6. Protocol: `set`](#2346-protocol-set)
+    - [2.4. DB schema](#24-db-schema)
+      - [2.4.1. Config DB](#241-config-db)
+        - [2.4.1.1. Global syslog table](#2411-global-syslog-table)
+        - [2.4.1.2. SSIP table](#2412-ssip-table)
+      - [2.4.2. Data sample](#242-data-sample)
+      - [2.4.3. Configuration sample](#243-configuration-sample)
+      - [2.4.4. Configuration migration](#244-configuration-migration)
+    - [2.5. Flows](#25-flows)
+      - [2.5.1. SSIP add](#251-ssip-add)
+        - [2.5.1.1. Figure 1: SSIP add flow](#2511-figure-1-ssip-add-flow)
+      - [2.5.2. SSIP remove](#252-ssip-remove)
+        - [2.5.2.1. Figure 2: SSIP remove flow](#2521-figure-2-ssip-remove-flow)
+    - [2.6. CLI](#26-cli)
+      - [2.6.1. Command structure](#261-command-structure)
+      - [2.6.2. Usage examples](#262-usage-examples)
+        - [2.6.2.1. Config command group](#2621-config-command-group)
+        - [2.6.2.2. Show command group](#2622-show-command-group)
+    - [2.7. YANG model](#27-yang-model)
+    - [2.8. Warm/Fast boot](#28-warmfast-boot)
+  - [3. Test plan](#3-test-plan)
+    - [3.1. Unit tests via VS](#31-unit-tests-via-vs)
+    - [3.2. Data plane tests via PTF](#32-data-plane-tests-via-ptf)
 
 
 ## Revision
@@ -63,7 +72,7 @@
 | Rev | Date       | Author         | Description           |
 |:---:|:----------:|:--------------:|:----------------------|
 | 0.1 | 18/04/2022 | Nazarii Hnydyn | Initial version       |
-| 0.2 | 08/01/2023 | Ido Avraham    | Added syslog configuration capabilities. </br> Configure remote syslog servers: protocol, filter, log severity level. </br> Update global syslog configuration: log severity level, message format |
+| 0.2 | 08/01/2023 | Ido Avraham    | Added syslog configuration capabilities. Configure remote syslog servers: protocol, filter, log severity level. Update global syslog configuration: log severity level, message format |
 
 ## About this manual
 
@@ -73,10 +82,12 @@ This document provides general information about Syslog Source IP implementation
 
 This document describes the high level design of Syslog Source IP feature in SONiC
 
-**In scope:**  
+**In scope:**
+
 1. Syslog Source IP configuration for UDP protocol
 
-**Out of scope:**  
+**Out of scope:**
+
 1. Syslog Source IP configuration for TCP protocol
 
 ## Abbreviations
@@ -98,18 +109,18 @@ This document describes the high level design of Syslog Source IP feature in SON
 
 ## List of figures
 
-- [Figure 1: SSIP add flow](#figure-1-ssip-add-flow)  
-- [Figure 2: SSIP remove flow](#figure-2-ssip-remove-flow)
+- [Figure 1: SSIP add flow](#2511-figure-1-ssip-add-flow)
+- [Figure 2: SSIP remove flow](#2521-figure-2-ssip-remove-flow)
 
 ## List of tables
 
-- [Table 1: Event logging](#2241-table-1-event-logging)
-- [Table 2: Syslog global config Module](#3211-table-2-syslog-global-config-module)
-- [Table 3: Syslog Forwarding Output Module](#3212-table-3-syslog-forwarding-output-module)
-- [Table 4: Global configuration parameters](#3321-table-4-global-configuration-parameters)
-- [Table 5: SSIP parameters](#3331-table-5-ssip-parameters)
+- [Table 1: Event logging](#1241-table-1-event-logging)
+- [Table 2: Syslog global config Module](#2211-table-2-syslog-global-config-module)
+- [Table 3: Syslog Forwarding Output Module](#2212-table-3-syslog-forwarding-output-module)
+- [Table 4: Global configuration parameters](#2321-table-4-global-configuration-parameters)
+- [Table 5: SSIP parameters](#2331-table-5-ssip-parameters)
 
-# 1. Introduction
+## 1. Introduction
 
 ## 1.1. Feature overview
 
@@ -125,6 +136,7 @@ The feature doesn't change the existing DB schema which makes it fully backward 
 ### 1.2.1. Functionality
 
 **This feature will support the following functionality:**
+
 1. Syslog Source IP address configuration
 2. Syslog server port configuration
 3. Syslog VRF device support
@@ -135,6 +147,7 @@ The feature doesn't change the existing DB schema which makes it fully backward 
 ### 1.2.2. Command interface
 
 **This feature will support the following commands:**
+
 1. config: add/delete syslog server configuration
 2. show: display syslog server configuration
 3. config: set/unset global syslog configuration
@@ -143,12 +156,14 @@ The feature doesn't change the existing DB schema which makes it fully backward 
 ### 1.2.3. Error handling
 
 **This feature will provide error handling for the next situations:**
+
 1. Invalid object reference
 2. Invalid options/parameters
 
 ### 1.2.4. Event logging
 
 **This feature will provide event logging for the next situations:**
+
 1. Syslog server add/delete
 
 #### 1.2.4.1. Table 1: Event logging
@@ -158,16 +173,17 @@ The feature doesn't change the existing DB schema which makes it fully backward 
 | Syslog server add/delete: success | NOTICE   |
 | Syslog server add/delete: error   | ERROR    |
 
-# 2. Design
+## 2. Design
 
 ## 2.1. Overview
 
-SSIP will reuse syslog `omfwd` functionality which offers the next features:  
+SSIP will reuse syslog `omfwd` functionality which offers the next features:
+
 1. Source IP address configuration
 2. Server port configuration
 3. VRF device configuration
 4. Server protocol configuration
-5. Messages regex filtering 
+5. Messages regex filtering
 6. Messages severity filtering
 
 ## 2.2. Syslog Forwarding Output Module
@@ -212,11 +228,12 @@ SSIP will reuse syslog `omfwd` functionality which offers the next features:
 
 ### 2.2.2. IpFreeBind
 
-**IP_FREEBIND (since Linux 2.4)**
-```
+IP_FREEBIND (since Linux 2.4)
+
+```text
 If enabled, this boolean option allows binding to an IP address that is nonlocal or does not (yet) exist.
-This permits listening on a socket, without requiring the underlying network interface  
-or the specified dynamic IP address to be up at the time that the application is trying to bind to it.  
+This permits listening on a socket, without requiring the underlying network interface
+or the specified dynamic IP address to be up at the time that the application is trying to bind to it.
 This option is the per-socket equivalent of the ip_nonlocal_bind.
 ```
 
@@ -233,38 +250,42 @@ Configuration management of `rsyslogd` is done by `rsyslog-config` service.
 The service is triggered by CLI once data is validated and pushed to Config DB.  
 
 The `rsyslog-config` service performs the next actions:
+
 1. Renders `rsyslog.conf.j2` template with `sonic-cfggen` to generate a new `rsyslogd` config file
 2. Restarts `rsyslog` service which triggers `rsyslogd` to load a new config file
 
 ### 2.3.2. global syslog configuration
 
 #### 2.3.2.1. Table 4: Global configuration parameters
+
 | SONiC                 | Rsyslogd | Config DB Schema                           |
 |:----------------------|:---------|:-------------------------------------------|
 | format                | template | SYSLOG_CONFIG\|GLOBAL\|format              |
 | severity              | priority | SYSLOG_CONFIG\|GLOBAL\|severity            |
 | welf_firewall_name    | severity | SYSLOG_CONFIG\|GLOBAL\|welf_firewall_name  |
 
-* severity: this field is a global log severity. 
-  this will be the default value for all the servers in the system
-  unless overridden by setting the `server.severity` field.
-  for example you can look at `2.4.3 configuration sample`
-  server "4.4.4.4" does not set `severity` field so it will use this global severity value.
-  server "4.4.4.5" does set it so it will use his local value and not this global value.
+**Note:** severity - this field is a global log severity.
+This will be the default value for all the servers in the system
+unless overridden by setting the `server.severity` field.
+For example you can look at `2.4.3 configuration sample`
+server "4.4.4.4" does not set `severity` field so it will use this global severity value.
+server "4.4.4.5" does set it so it will use his local value and not this global value.
   
 
-#### 2.3.2.2. Format: `set`:
+#### 2.3.2.2. Format: `set`
 
 Format:
-template(name="WelfFormat" type="string" string="%TIMESTAMP% %HOSTNAME% id=firewall time=\"%timereported\
-:::date-year%-%timereported:::date-month%-%timereported:::date-day% %timereported:::date-hour%:%timereported:::date-minute%:%timereported\
-:::date-second%\" fw=\"{{ firewall-name  }}\" pri=%syslogpriority% msg=\"%syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\"\n")
+
+```text
+template(name="WelfFormat" type="string" string="%TIMESTAMP% %HOSTNAME% id=firewall time=\"%timereported:::date-year%-%timereported:::date-month%-%timereported:::date-day% %timereported:::date-hour%:%timereported:::date-minute%:%timereported:::date-second%\" fw=\"{{ firewall-name  }}\" pri=%syslogpriority% msg=\"%syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\"\n")
+```
 
 ### 2.3.3. SSIP parameters
 
 **SSIP will have the next parameter mapping:**
 
 #### 2.3.3.1. Table 5: SSIP parameters
+
 | SONiC         | Rsyslogd | Config DB Schema                   |
 |:--------------|:---------|:-----------------------------------|
 | key           | target   | SYSLOG_SERVER\|key                 |
@@ -278,10 +299,11 @@ template(name="WelfFormat" type="string" string="%TIMESTAMP% %HOSTNAME% id=firew
 
 ### 2.3.4. SSIP configuration
 
-SSIP offers `vrf` and `source` parameters for flexible configuration management.  
+SSIP offers `vrf` and `source` parameters for flexible configuration management.
 Each parameter combination requires a dedicated handling approach.
 
 **Note:**
+
 1. The destination might be not reachable over the specified `vrf`/`source`: no way to check - user's responsibility
 2. Additional validation is required when MGMT/DATA VRF is removed while reference still exists in syslog configuration
 3. `severity` field will be default log severity for rules that do not define it.
@@ -291,40 +313,47 @@ Each parameter combination requires a dedicated handling approach.
 Linux kernel decides which source IP to use within the default VRF.
 
 **Example:**
-```
+
+```text
 *.notice action(type="omfwd" target="2.2.2.2" protocol="udp")
 ```
 
 #### 2.3.4.2. VRF/Source: `unset/set`
 
-Check if source IP is configured on any default VRF member:  
+Check if source IP is configured on any default VRF member:
 yes - set source IP, no - generate error
 
 **Example:**
-```
+
+```text
 *.notice action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1")
 ```
 
 #### 2.3.4.3. VRF/Source: `set/unset`
 
 Check VRF type:
+
 1. Default
 2. MGMT
 3. DATA
 
 Default VRF:
+
 1. Skip VRF configuration
 
 MGMT VRF:
-1. Check if MGMT VRF is enabled:  
-yes - set VRF, no - generate error
+
+1. Check if MGMT VRF is enabled:
+   yes - set VRF, no - generate error
 
 DATA VRF:
-1. Check if VRF is a member of SONiC VRF table:  
-yes - set VRF, no - generate error
+
+1. Check if VRF is a member of SONiC VRF table:
+   yes - set VRF, no - generate error
 
 **Example:**
-```
+
+```text
 Default VRF:
 *.notice action(type="omfwd" target="2.2.2.2" protocol="udp")
 MGMT VRF:
@@ -336,29 +365,34 @@ DATA VRF:
 #### 2.3.4.4. VRF/Source: `set/set`
 
 Check VRF type:
+
 1. Default
 2. MGMT
 3. DATA
 
 Default VRF:
-1. Check if source IP is configured on any DEFAULT VRF member:  
-yes - set source IP, no - generate error
+
+1. Check if source IP is configured on any DEFAULT VRF member:
+   yes - set source IP, no - generate error
 2. Skip VRF configuration
 
 MGMT VRF:
-1. Check if MGMT VRF is enabled:  
-yes - set VRF, no - generate error
-2. Check if source IP is configured on any MGMT VRF member:  
-yes - set source IP, no - generate error
+
+1. Check if MGMT VRF is enabled:
+   yes - set VRF, no - generate error
+2. Check if source IP is configured on any MGMT VRF member:
+   yes - set source IP, no - generate error
 
 DATA VRF:
-1. Check if VRF is a member of SONiC VRF table:  
-yes - set VRF, no - generate error
-2. Check if source IP is configured on any DATA VRF member:  
-yes - set source IP, no - generate error
+
+1. Check if VRF is a member of SONiC VRF table:
+   yes - set VRF, no - generate error
+2. Check if source IP is configured on any DATA VRF member:
+   yes - set source IP, no - generate error
 
 **Example:**
-```
+
+```text
 Default VRF:
 *.notice action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1")
 MGMT VRF:
@@ -371,30 +405,32 @@ DATA VRF:
 
 Log regex filter
 
-Filter:
-    Filter value can be either Include or Exclude.
+**Filter:**
 
-    Include:
-    Compares the log string against the provided POSIX ERE regular expression.
-    yes - sends log string to remote server, no - do not send
+Filter value can be either Include or Exclude.
 
-    Exclude:
-    Compares the log string against the provided POSIX ERE regular expression.
-    yes - does not send string log to remote server, no - sends
+**Include:**
+Compares the log string against the provided POSIX ERE regular expression.
+yes - sends log string to remote server, no - do not send
 
-Protocol:
+**Exclude:**
+Compares the log string against the provided POSIX ERE regular expression.
+yes - does not send string log to remote server, no - sends
+
+**Protocol:**
 messages are forwarded via configured protocol
 
-Severity:
+**Severity:**
 sends logs with severity equal or higher then configured
 
 **Example:**
-```
+
+```text
 Include:
-:msg, ereregex, "include_str*" 
+:msg, ereregex, "include_str*"
 *.notice action(type="omfwd" Target="4.4.4.4" Port="514" Protocol="tcp" Device="eth0" Template="SONiCFileFormat")
 Exclude:
-:msg, !ereregex, "exclude_str*" 
+:msg, !ereregex, "exclude_str*"
 *.info action(type="omfwd" Target="4.4.4.5" Port="514" Protocol="udp" Device="eth0" Template="SONiCFileFormat")
 ```
 
@@ -403,7 +439,8 @@ Exclude:
 messages are forwarded via configured protocol
 
 **Example:**
-```
+
+```text
 *.notice action(type="omfwd" Target="5.5.5.5" Port="514" Protocol="tcp" Device="eth0" Template="SONiCFileFormat")
 ```
 
@@ -412,6 +449,7 @@ messages are forwarded via configured protocol
 ### 2.4.1. Config DB
 
 #### 2.4.1.1. Global syslog table
+
 ```abnf
 ; define schema for syslog global configuration attributes under SYSLOG_CONFIG|GLOBAL
 
@@ -429,6 +467,7 @@ log-level       = "debug" / "info" / "notice" / "warn" / "error" / "crit"
 ```
 
 #### 2.4.1.2. SSIP table
+
 ```abnf
 ; defines schema for syslog table configuration attributes
 key = SYSLOG_SERVER|server_ip_address ; server IP address. Must be unique
@@ -474,6 +513,7 @@ log-level   = "debug" / "info" / "notice" / "warn" / "error" / "crit"
 ### 2.4.2. Data sample
 
 **Config DB:**
+
 ```bash
 redis-cli -n 4 HGETALL 'SYSLOG_SERVER|2.2.2.2'
 1) "source"
@@ -529,7 +569,7 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|4.4.4.5'
  7) "protocol"
  8) "udp"
  9) "filter_type"
-10) "exlude"
+10) "exclude"
 11) "filter_regex"
 12) "exclude_str*"
 13) "severity"
@@ -544,12 +584,13 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|5.5.5.5'
  6) "default"
  7) "protocol"
  8) "tcp"
- 
- ```
+
+```
 
 ### 2.4.3. Configuration sample
 
 **Syslog remote logging:**
+
 ```json
 {
     "SYSLOG_SERVER": {
@@ -589,8 +630,8 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|5.5.5.5'
             "source": "5.5.5.5",
             "port": "514",
             "vrf": "default",
-            "protocol": "tcp",
-        },
+            "protocol": "tcp"
+        }
     },
     "SYSLOG_CONFIG": {
         "format": "welf",
@@ -623,7 +664,8 @@ No special handling is required
 ### 2.6.1. Command structure
 
 **User interface**:
-```
+
+```text
 config
 |--- syslog
      |--- add <server_ip> OPTIONS
@@ -635,7 +677,8 @@ show
 
 **Options:**
 
-_config syslog add_
+config syslog add:
+
 1. `-s|--source` - source ip address
 2. `-p|--port` - server udp port
 3. `-r|--vrf` - vrf device
@@ -649,6 +692,7 @@ _config syslog add_
 #### 2.6.2.1. Config command group
 
 **The following command adds/deletes syslog server:**
+
 ```bash
 config syslog add '2.2.2.2' \
 --source '1.1.1.1' \
@@ -660,6 +704,7 @@ config syslog del '2.2.2.2'
 #### 2.6.2.2. Show command group
 
 **The following command shows syslog server configuration:**
+
 ```bash
 root@sonic:/home/admin# show syslog
 SERVER IP    SOURCE IP    PORT    VRF        PROTOCOL  FILTER_TYPE   FILTER REGEX  SEVERITY
@@ -677,6 +722,7 @@ SERVER IP    SOURCE IP    PORT    VRF        PROTOCOL  FILTER_TYPE   FILTER REGE
 An existing YANG model `sonic-syslog.yang` will be extended in order to provide support for SSIP.
 
 **Skeleton code:**
+
 ```yang
 module sonic-syslog {
 
@@ -850,19 +896,21 @@ module sonic-syslog {
 
 No special handling is required
 
-# 3. Test plan
+## 3. Test plan
 
-## 3.1. Unit tests via VS
+### 3.1. Unit tests via VS
 
 SSIP basic configuration test:
+
 1. Verify rsyslog.conf after syslog server creation/removal
 
 SSIP extended configuration test:
+
 1. Create syslog server with IPv4/IPv6 source IP
 2. Verify rsyslog.conf
 3. Create syslog server with default/mgmt/data VRF device
 4. Verify rsyslog.conf
 
-## 3.2. Data plane tests via PTF
+### 3.2. Data plane tests via PTF
 
 TBD


### PR DESCRIPTION
Complete markdownlint cleanup:
- Convert H1 headings to H2
- Add blank lines around lists, code blocks, tables
- Fix HTML tags and formatting issues
- Update Table of Contents

Addresses markdownlint requirements from PR #2120