### PR TITLE
[ssw][ha] add doc for dpu restart

### DIFF
--- a/doc/smart-switch/high-availability/dpu_reboot.md
+++ b/doc/smart-switch/high-availability/dpu_reboot.md
@@ -14,7 +14,7 @@ The following are the proposed actions during DPU reboot.
     Note that database is cleaned up when swss is restarted, so both DPU reboot and critical process restart scenarios should be covered.   
 1. SDN controller needs to monitor NPU `STATE_DB` entries below: 
 
-    1. `DASH_DPU_RESET_INFO_TABLE|DPU<dpu_index>: {'reset_status': 'true|false', 'timestamp': timestamp, 'dpu_id': dpu_id, 'vdpu_id': vdpu_id}`  
+    1. `DPU_RESET_INFO_TABLE|DPU<dpu_index>: {'reset_status': 'true|false', 'timestamp': timestamp, 'dpu_id': dpu_id, 'vdpu_id': vdpu_id}`  
         This table will be updated by hamgrd based on `CHASSIS_STATE_DB|DPU_STATE`. Either `dpu_control_plane_state` or `dpu_midplane_link_state` being down will trigger hamgrd to set `reset_status` to `true`.
         Controller will update the status to `false` when it finishes the service provision and HA programming after DPU is up.        
  
@@ -47,8 +47,8 @@ sequenceDiagram
 
     DPU->>DPU: 1. DPU shutdown
     pmon->>NPU CHASSIS_STATE_DB: 2. Update dpu state to down
-    hamgrd->>NPU STATE_DB: 3. update local vdpu state in `DASH_HA_SCOPE_STATE` table, update `DASH_DPU_RESET_INFO_TABLE` and `CHASSIS_MODULE_TABLE`
-    NPU STATE_DB->>SDN Controller: 4. DASH_DPU_RESET_INFO_TABLE|DPU0: {"reset_status": "true", timestamp: <timestamp>, dpu_id: <dpu_id>, vdpu_id: <vdpu_id>} CHASSIS_MODULE_TABLE|DPU0: {"dpu_ready": "false"}
+    hamgrd->>NPU STATE_DB: 3. update local vdpu state in `DASH_HA_SCOPE_STATE` table, update `DPU_RESET_INFO_TABLE` and `CHASSIS_MODULE_TABLE`
+    NPU STATE_DB->>SDN Controller: 4. DPU_RESET_INFO_TABLE|DPU0: {"reset_status": "true", timestamp: <timestamp>, dpu_id: <dpu_id>, vdpu_id: <vdpu_id>} CHASSIS_MODULE_TABLE|DPU0: {"dpu_ready": "false"}
     hamgrd->>DPU_APPL_DB: 5. hamgrd remove passive BFD sessions
     SDN Controller->>hamgrd: 6. Delete HA_SCOPE_CONFIG and HA_SET_CONFIG
     hamgrd->>DPU_APPL_DB: 7. Delete HA_SET, HA_SCOPE
@@ -64,5 +64,5 @@ sequenceDiagram
 
 
     SDN Controller->>hamgrd: 16. Create DASH objects, HA_SCOPE_CONFIG and HA_SET_CONFIG 
-    SDN Controller->>NPU STATE_DB: 17. Set value DASH_DPU_RESET_INFO_TABLE|DPU0: {"reset_status": "false", timestamp:<timestamp>}
+    SDN Controller->>NPU STATE_DB: 17. Set value DPU_RESET_INFO_TABLE|DPU0: {"reset_status": "false", timestamp:<timestamp>}
 ```


### PR DESCRIPTION
When DPU restarts (either as a planned or an unexpected event), DPU_[APPL|STATE] _DB that are hosted on NPU will not be restarted along with as DPU. This causes some states to be out of sync and leads to unexpected behaviors in HA scenarios. 

Adding doc for solution proposal. Pending review.

sign-off: Jing Zhang zhangjing@microsoft.com