### PR TITLE
Address PR review comments for EVPN VxLAN Multihoming HLD

### DIFF
--- a/doc/vxlan/EVPN/EVPN_VxLAN_Multihoming.md
+++ b/doc/vxlan/EVPN/EVPN_VxLAN_Multihoming.md
@@ -2,7 +2,7 @@
 
 # High Level Design Document
 
-Rev 1.4
+Rev 1.5
 
 # Table of Contents
 
@@ -484,10 +484,9 @@ The below steps explain the MAC learning and ageing scenario in the EVPN MH netw
     - (a) FRR updates the kernel FDB entry with IN_TIMER flag and starts hold-timer.
     - (c) Fdbsyncd receives notification from kernel with IN_TIMER flag set, and it replaces the VXLAN_FDB_TABLE entry with ageing=enabled, type=none.
     - (d) Fdborch converts the FDB entry in HW to dynamic (removes SAI_FDB_ENTRY_TYPE_STATIC, sets SAI_FDB_ENTRY_ATTR_ALLOW_MAC_MOVE=False).
-    - (e) MAC learn event is received from SAI if the traffic hits after the entry becomes dynamic.
-    - (f) Fdborch populates STATE_FDB_TABLE table (type=dynamic) and Fdbsyncd installs local FDB entry into the kernel.
-    - (g) FRR advertises Type-2 route with Proxy=0.
-    - (h) At step (e) above, if there is no traffic, the MAC will be removed from kernel by FRR after the hold-timer expiry. Fdbsyncd will remove the VXLAN_FDB_TABLE entry and mac will be removed from HW.
+    - (e) If traffic hits after the entry becomes dynamic, a MAC learn event may be received from SAI if the entry is not already present in hardware. Fdborch populates STATE_FDB_TABLE table (type=dynamic) and Fdbsyncd installs local FDB entry into the kernel.
+    - (f) FRR advertises Type-2 route with Proxy=0.
+    - (g) At step (e) above, if there is no traffic, the MAC will be removed from kernel by FRR after the hold-timer expiry. Fdbsyncd will remove the VXLAN_FDB_TABLE entry and mac will be removed from HW.
 
 <a id="226-Static-Anycast-Gateway"></a>
 ### 2.2.6 Static Anycast Gateway


### PR DESCRIPTION
Latest updates:

- Add detailed LAG failure handling sequence with SAI_BRIDGE_PORT_ATTR_BRIDGE_PORT_SET_SWITCHOVER
- Replace mesh-bit references with proper SAI attributes (SAI_FDB_ENTRY_TYPE_STATIC and SAI_FDB_ENTRY_ATTR_ALLOW_MAC_MOVE)


Merged HLD : https://github.com/sonic-net/SONiC/pull/1702

NEWLY PRs tested on a branch on master. PRs are consolidated per module. Each PR has multiple commits.


| Module | PR Title | State |
| --- | --- | --- |
| sonic-buildimage | [Add FRR bgpd crash fix patch for EVPN MH path handling](https://github.com/sonic-net/sonic-buildimage/pull/27683)| ![PR state](https://img.shields.io/github/pulls/detail/state/Azure/sonic-buildimage/27683) |
| sonic-buildimage | [Add EVPN-MH YANG model support](https://github.com/sonic-net/sonic-buildimage/pull/27543) | ![PR state](https://img.shields.io/github/pulls/detail/state/Azure/sonic-buildimage/27543) |
| sonic-buildimage | [Add EVPN-MH FRR patch support](https://github.com/sonic-net/sonic-buildimage/pull/27544) | ![PR state](https://img.shields.io/github/pulls/detail/state/Azure/sonic-buildimage/27544) |
| sonic-swss-common | [Add L2 nexthop group table and raw netlink message handling](https://github.com/sonic-net/sonic-swss-common/pull/1155) | ![PR state](https://img.shields.io/github/pulls/detail/state/Azure/sonic-swss-common/1155) |
| sonic-swss | [Add standalone EVPN-MH code and tests](https://github.com/sonic-net/sonic-swss/pull/4608) | ![PR state](https://img.shields.io/github/pulls/detail/state/Azure/sonic-swss/4608) |
| sonic-swss | [EVPN-MH code wiring](https://github.com/sonic-net/sonic-swss/pull/4615) | ![PR state](https://img.shields.io/github/pulls/detail/state/Azure/sonic-swss/4615) |
| sonic-utilities | [Add CLI commands for EVPN VXLAN Multihoming configuration](https://github.com/sonic-net/sonic-utilities/pull/4247) | ![PR state](https://img.shields.io/github/pulls/detail/state/Azure/sonic-utilities/4247) |
| sonic-linux-kernel | [Add kernel patches for EVPN VXLAN Multihoming support](https://github.com/sonic-net/sonic-linux-kernel/pull/540) | ![PR state](https://img.shields.io/github/pulls/detail/state/Azure/sonic-linux-kernel/540) |
| sonic iproute2 patch | [Add protocol field support](https://github.com/sonic-net/sonic-buildimage/pull/26664) | ![PR state](https://img.shields.io/github/pulls/detail/state/Azure/sonic-buildimage/26664) |









---

OLD:
| sonic-buildimage | [Add EVPN VXLAN Multihoming build infrastructure and integration](https://github.com/sonic-net/sonic-buildimage/pull/25678) | ![PR state](https://img.shields.io/github/pulls/detail/state/Azure/sonic-buildimage/25678) |
| sonic-swss | [Add EVPN VXLAN Multihoming feature support](https://github.com/sonic-net/sonic-swss/pull/4262) | 

OLD PRs for reference ONLY (all above PRs are superset)

| Module | Detail| PR | Status | 
| --- | --- | --- | --- | 
|sonic-utilities| Config | [4247](https://github.com/sonic-net/sonic-utilities/pull/4247)| Open |
|sonic-swss|Cfgmgr | [4036](https://github.com/sonic-net/sonic-swss/pull/4036)| Open | 
|sonic-buidimage| Data Models | [23373](https://github.com/sonic-net/sonic-buildimage/pull/23373) | Open / In-progress |
|sonic-swss | evpnmhorch | [3771](https://github.com/sonic-net/sonic-swss/pull/3771) | Open |
|sonic-swss | shlorch | [3769](https://github.com/sonic-net/sonic-swss/pull/3769) | Open |
|sonic-swss-common | | [890](https://github.com/sonic-net/sonic-swss-common/pull/890)| Open|
|sonic-swss-common | shlorch | [1051](https://github.com/sonic-net/sonic-swss-common/pull/1051) | Merged | 
|sonic-swss-common | APP_DB  | [952](https://github.com/sonic-net/sonic-swss-common/pull/952) | Open - NHG table - BCM PR | 
|sonic-swss | fdborch/neighorch | [3914](https://github.com/sonic-net/sonic-swss/pull/3914)| Open |
|sonic-swss | vxlanorch | [3913](https://github.com/sonic-net/sonic-swss/pull/3913)| Open |
|sonic-swss | fdbsyncd | [4039](https://github.com/sonic-net/sonic-swss/pull/4039) | Open |
|sonic-swss | fpmsyncd | [4038](https://github.com/sonic-net/sonic-swss/pull/4038)| Open |
|sonic-swss | Neighsyncd | [4037](https://github.com/sonic-net/sonic-swss/pull/4037)| Open |
|sonic-swss | fdbsyncd |[4206](https://github.com/sonic-net/sonic-swss/pull/4206)|Open |
|sonic-frr | FRR | [19438](https://github.com/FRRouting/frr/pull/19438) | Open / In-progress |
|sonic-linux-kernel | protocol field | [PR](https://lore.kernel.org/netdev/20250816031145.1153429-1-mrghosh@cisco.com/T/#u) |Open|
|sonic-linux-kernel | MH peer sync| [PR](https://github.com/torvalds/linux/commit/03dc03fa0432a9160c4fcbdb86f274e6b4587972)| Nvidia also need to open PR for MH peer sync flag |
|sonic-buildimage | iproute2 |  [PR ](https://lore.kernel.org/netdev/20250818193756.277327-1-mrghosh@cisco.com/T/#u)  | Open / In-progress |