### PR TITLE
Add HLD for sonic-pcap: one-command packet capture

### DIFF
--- a/doc/sonic-pcap/sonic-pcap-hld.md
+++ b/doc/sonic-pcap/sonic-pcap-hld.md
@@ -578,7 +578,7 @@ No impact. sonic-pcap creates ephemeral mirror sessions for debugging. Sessions 
 
 ## 18. Open Questions
 
-1. **SAI vendor support timeline**: Which vendors will implement `MONITOR_PORT=CPU` first? Cisco Silicon One is the most likely candidate (IOS-XR EPC on same hardware proves NPU capability).
+1. **SAI vendor support timeline**: Which vendors will implement `MONITOR_PORT=CPU` first? Each vendor already has ASIC-to-CPU infrastructure that could be extended.
 
 2. **Netdev naming convention**: Should the CPU mirror netdev be standardized as `mirror0` across all vendors, or should sonic-pcap discover it dynamically? Current design supports both (checks known names, falls back to config file).
 


### PR DESCRIPTION
## Summary

Adds a High-Level Design document for **sonic-pcap**, a CLI tool that provides one-command data-plane packet capture on SONiC switches.

- Three capture modes: mirror-to-CPU (default), mirror-to-port, CPU-only
- Auto-managed mirror session lifecycle with signal-safe cleanup
- Inline educational explanations that teach users what they're seeing
- Live ASCII stats (packet count, rate, drops)
- Platform capability detection and graceful degradation

## Key Changes Required

1. **sonic-swss** (`mirrororch.cpp`): One-line fix to accept `Port::CPU` in `validateDstPort()`
2. **Vendor SAI**: Accept CPU port OID as `SAI_MIRROR_SESSION_ATTR_MONITOR_PORT` — uses existing API, no spec changes
3. **sonic-utilities** (or standalone): New `sonic-pcap` CLI tool

## Related Issue

Closes #2262

## Files

- `doc/sonic-pcap/sonic-pcap-hld.md` — Full HLD following SONiC template

## Test Plan

- [ ] CLI flag parsing and validation
- [ ] Mirror session CONFIG_DB create/delete/poll lifecycle
- [ ] Platform capability detection (STATE_DB SWITCH_CAPABILITY)
- [ ] tcpdump subprocess management and stats parsing
- [ ] Signal handling and stale session cleanup
- [ ] Full orchestration integration tests
- 122 unit tests already passing against the reference implementation