### PR TITLE
Update ssw ha hld

### DIFF
--- a/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md
+++ b/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md
@@ -561,6 +561,7 @@ When a HA set configuration on NPU side contains a local DPU, `hamgrd` will crea
 | | | ha_term | The target term of this scope. It should be an integer. |
 | | | flow_reconcile_requested | If true, flow reconcile will be initiated. (Message Only. Not saved in DB.) |
 | | | activate_role_requested | If true, HA role will be activated. (Message Only. Not saved in DB.) |
+| | | brainsplit_recovered | If true, reset the DPU_STATE_DB `brainsplit_recover_pending` flag back to false. (Message Only. Not saved in DB.) |
 
 ##### 2.3.1.3. Flow sync sessions
 

--- a/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md
+++ b/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md
@@ -561,7 +561,7 @@ When a HA set configuration on NPU side contains a local DPU, `hamgrd` will crea
 | | | ha_term | The target term of this scope. It should be an integer. |
 | | | flow_reconcile_requested | If true, flow reconcile will be initiated. (Message Only. Not saved in DB.) |
 | | | activate_role_requested | If true, HA role will be activated. (Message Only. Not saved in DB.) |
-| | | brainsplit_recovered | If true, reset the DPU_STATE_DB `brainsplit_recover_pending` flag back to false. (Message Only. Not saved in DB.) |
+| | | brainsplit_recovered | If true, DPUs are recovered from brainsplit. (Message Only. Not saved in DB.) |
 
 ##### 2.3.1.3. Flow sync sessions
 

--- a/doc/smart-switch/high-availability/smart-switch-ha-hld.md
+++ b/doc/smart-switch/high-availability/smart-switch-ha-hld.md
@@ -1174,7 +1174,7 @@ Planned switchover starts from a standby node, because in order to avoid flow lo
 
     Hence, although the traffic can land on both DPUs, there is only 1 decision maker – DPU1.
 
-    Note that, right before entering `SwitchingToStandby` state, DPU0 can still initiate inline sync, hence after it enters `SwitchingToStandby` state, it might still receive inline sync ACK packets from DPU1. These packets should be sent out instead of dropped. As a matter of fact, it should alwasy be sent out into the network whenever an inline sync ACK packet is seen , regardless the HA state.   
+    Note that, right before entering `SwitchingToStandby` state, DPU0 can still initiate inline sync, hence after it enters `SwitchingToStandby` state, it might still receive inline sync ACK packets from DPU1. These packets should be sent out instead of dropped. As a matter of fact, it should always be sent out into the network whenever an inline sync ACK packet is seen , regardless the HA state.
 
 5. After DPU1 receives `HAStateChanged` event from DPU0, it drives itself to Active state and notifies DPU0 back with `HAStateChanged`.
 

--- a/doc/smart-switch/high-availability/smart-switch-ha-hld.md
+++ b/doc/smart-switch/high-availability/smart-switch-ha-hld.md
@@ -1174,6 +1174,8 @@ Planned switchover starts from a standby node, because in order to avoid flow lo
 
     Hence, although the traffic can land on both DPUs, there is only 1 decision maker – DPU1.
 
+    Note that, right before entering `SwitchingToStandby` state, DPU0 can still initiate inline sync, hence after it enters `SwitchingToStandby` state, it might still receive inline sync ACK packets from DPU1. These packets should be sent out instead of dropped. As a matter of fact, it should alwasy be sent out into the network whenever an inline sync ACK packet is seen , regardless the HA state.   
+
 5. After DPU1 receives `HAStateChanged` event from DPU0, it drives itself to Active state and notifies DPU0 back with `HAStateChanged`.
 
     <p align="center"><img alt="HA planned switchover step 4" src="./images/ha-planned-events-switchover-step-5.svg"></p>


### PR DESCRIPTION
Update ha hld to:
1. include requirement of not dropping ha ack packets in planned swo
2. add new field `brainsplit_recovered` in DPU_APPL_DB HA_SCOPE_TABLE, so dashhaorch knows when to reset the brain split recover pending flag in DPU_STATE_DB. 
 
sign-off: Jing Zhang zhangjing@microsoft.com 