### PR TITLE
[sfp-cmis] Document CMIS state machine timeouts

### DIFF
--- a/doc/sfp-cmis/cmis-init.md
+++ b/doc/sfp-cmis/cmis-init.md
@@ -276,11 +276,11 @@ to support multiple CMIS transceivers in one single thread.
 
   | Start state (timer armed) | End state (timer checked) | Desired condition | Timeout value | On timeout |
   |:---|:---|:---|:---|:---|
-  | `CMIS_STATE_DP_DEINIT` | `CMIS_STATE_AP_CONF` | `ModuleReady` | `max(modulePwrUpDuration, dpDeinitDuration)` | `force_cmis_reinit(retries+1)` |
-  | `CMIS_STATE_DP_DEINIT` | `CMIS_STATE_AP_CONF` | `DataPathDeactivated` | `max(modulePwrUpDuration, dpDeinitDuration)` (same timer, reused) | `force_cmis_reinit(retries+1)` |
-  | `CMIS_STATE_DP_DEINIT` | `CMIS_STATE_DP_INIT` | `ConfigSuccess` | `max(modulePwrUpDuration, dpDeinitDuration)` (inherited; AP_CONF does not re-arm before transitioning to DP_INIT) | `force_cmis_reinit(retries+1)` |
-  | `CMIS_STATE_DP_INIT` | `CMIS_STATE_DP_TXON` | `DataPathInitialized` | `dpInitDuration` | `force_cmis_reinit(retries+1)` |
-  | `CMIS_STATE_DP_TXON` | `CMIS_STATE_DP_ACTIVATE` | `DataPathActivated` | `max(dpInitDuration, dpTxTurnOnDuration)` | `force_cmis_reinit(retries+1)` |
+  | `DP_DEINIT` | `AP_CONF` | `ModuleReady` | `max(modulePwrUpDuration, dpDeinitDuration)` | `force_cmis_reinit(retries + 1)` |
+  | `DP_DEINIT` | `AP_CONF` | `DataPathDeactivated` | `max(modulePwrUpDuration, dpDeinitDuration)` (same timer, reused) | `force_cmis_reinit(retries + 1)` |
+  | `DP_DEINIT` | `DP_INIT` | `ConfigSuccess` | `max(modulePwrUpDuration, dpDeinitDuration)` (inherited; `AP_CONF` does not re-arm before transitioning to `DP_INIT`) | `force_cmis_reinit(retries + 1)` |
+  | `DP_INIT` | `DP_TXON` | `DataPathInitialized` | `dpInitDuration` | `force_cmis_reinit(retries + 1)` |
+  | `DP_TXON` | `DP_ACTIVATE` | `DataPathActivated` | `max(dpInitDuration, dpTxTurnOnDuration)` | `force_cmis_reinit(retries + 1)` |
 
   Notes:
   - "Start state" = the state whose handler arms the timer (right before transitioning out).

--- a/doc/sfp-cmis/cmis-init.md
+++ b/doc/sfp-cmis/cmis-init.md
@@ -36,6 +36,7 @@ CMIS Application Initialization
   * [Table 2: References](#table-2-references)
   * [Table 3: Port Table Name Mappings](#table-3-port-table-name-mappings)
   * [Table 4: CMIS State Table](#table-4-cmis-state-table)
+  * [Table 5: CMIS State Machine Timeouts](#table-5-cmis-state-machine-timeouts)
 
 # Revision
 | Rev |     Date    |       Author        | Change Description                        |
@@ -263,6 +264,34 @@ to support multiple CMIS transceivers in one single thread.
       state transitioned to **READY**
   - The CMIS state transition diagram  
   ![](images/001.png)
+
+  ### Table 5 CMIS State Machine Timeouts
+
+  Each transition that waits on a hardware/datapath condition is bounded by a per-port
+  expiration timer (`cmis_expired`, armed via `update_cmis_state_expiration_time()`).
+  When the timer expires before the desired condition is observed, the state machine
+  invokes `force_cmis_reinit(retries + 1)` which resets the port back to **INSERTED**
+  and advances the retry counter. After `CMIS_MAX_RETRIES` is exceeded, the port is
+  moved to **FAILED**.
+
+  | Start state (timer armed) | End state (timer checked) | Desired condition | Timeout value | On timeout |
+  |:---|:---|:---|:---|:---|
+  | `CMIS_STATE_DP_DEINIT` | `CMIS_STATE_AP_CONF` | `ModuleReady` | `max(modulePwrUpDuration, dpDeinitDuration)` | `force_cmis_reinit(retries+1)` |
+  | `CMIS_STATE_DP_DEINIT` | `CMIS_STATE_AP_CONF` | `DataPathDeactivated` | `max(modulePwrUpDuration, dpDeinitDuration)` (same timer, reused) | `force_cmis_reinit(retries+1)` |
+  | `CMIS_STATE_DP_DEINIT` | `CMIS_STATE_DP_INIT` | `ConfigSuccess` | `max(modulePwrUpDuration, dpDeinitDuration)` (inherited; AP_CONF does not re-arm before transitioning to DP_INIT) | `force_cmis_reinit(retries+1)` |
+  | `CMIS_STATE_DP_INIT` | `CMIS_STATE_DP_TXON` | `DataPathInitialized` | `dpInitDuration` | `force_cmis_reinit(retries+1)` |
+  | `CMIS_STATE_DP_TXON` | `CMIS_STATE_DP_ACTIVATE` | `DataPathActivated` | `max(dpInitDuration, dpTxTurnOnDuration)` | `force_cmis_reinit(retries+1)` |
+
+  Notes:
+  - "Start state" = the state whose handler arms the timer (right before transitioning out).
+    "End state" = the state where the timer is checked.
+  - **AP_CONF** does not re-arm the timer; the budget armed in **DP_DEINIT** is reused
+    across three sequential checks (ModuleReady -> DataPathDeactivated -> ConfigSuccess),
+    so a slow `ModuleReady` consumes part of the budget available for the later checks.
+  - All durations are derived from the CMIS module's advertised timing fields
+    (`get_cmis_dp_deinit_duration_secs()`, `get_cmis_dp_init_duration_secs()`,
+    `get_cmis_dp_tx_turnon_duration_secs()`, `get_cmis_module_power_up_duration_secs()`)
+    plus a fixed `CMIS_EXPIRATION_BUFFER_MS` slack applied by `update_cmis_state_expiration_time()`.
 
   ### Conditions for Datapath init
 


### PR DESCRIPTION
## Summary

Adds **Table 5: CMIS State Machine Timeouts** to the CMIS Application Initialization HLD ([doc/sfp-cmis/cmis-init.md](https://github.com/sonic-net/SONiC/blob/master/doc/sfp-cmis/cmis-init.md)).

The CMIS state machine arms a per-port expiration timer (`cmis_expired`, set via `update_cmis_state_expiration_time()`) before any transition that waits on a hardware/datapath condition. If the condition is not observed before the timer expires, `force_cmis_reinit(retries + 1)` is invoked and the port is reset back to **INSERTED**; once `CMIS_MAX_RETRIES` is exceeded the port moves to **FAILED**. Today this behavior is spread across the code and not summarized anywhere in the HLD, which makes it hard to reason about timing budgets when debugging slow modules.

## What this PR adds

A new table that, for each timed transition, captures:

- **Start state** — the state whose handler arms the timer (right before transitioning out)
- **End state** — the state where the timer is checked
- **Desired condition** — the hardware/datapath signal being waited on (`ModuleReady`, `DataPathDeactivated`, `ConfigSuccess`, `DataPathInitialized`, `DataPathActivated`)
- **Timeout value** — derived from the module's advertised CMIS timing fields plus `CMIS_EXPIRATION_BUFFER_MS`
- **On timeout** — `force_cmis_reinit(retries + 1)`

It also calls out that **AP_CONF does not re-arm the timer**: the budget armed in **DP_DEINIT** is reused across three sequential checks (ModuleReady → DataPathDeactivated → ConfigSuccess), so a slow `ModuleReady` consumes part of the budget available for the later checks.

## Motivation

- Makes the HLD self-contained for anyone debugging CMIS init timeouts or tuning module timing.
- Documents the (intentional) shared-timer behavior across DP_DEINIT → AP_CONF → DP_INIT so future changes don't break that assumption silently.

## Type of change

- [x] Documentation update (HLD)
- [ ] Code change
- [ ] DB schema change
- [ ] SAI change
- [ ] CLI/YANG change

## Testing

Documentation-only change. Markdown rendering verified locally; new TOC entry links to the new section anchor.

## Backward compatibility

No code, schema, or API changes. No impact on existing releases.

**ADO:**  37936922