### PR TITLE
[doc]: Update route-performance strategy for knob consolidation

### DIFF
--- a/doc/route-performance/strategies/large-scale-datacenter-clos-fabric.md
+++ b/doc/route-performance/strategies/large-scale-datacenter-clos-fabric.md
@@ -126,7 +126,7 @@ orchagent → ResponsePublisher::publish() → Redis PUB/SUB + APPL_STATE_DB wri
   → fpmsyncd NotificationConsumer → sendOffloadReply() → FPM → zebra RTM_F_OFFLOAD → route advertised
 ```
 
-This is the remaining Redis bottleneck on orchagent's main thread. `ResponsePublisher` async offload moves APPL_STATE_DB writes, notifications, and recordings to a background thread, controlled by `DEVICE_METADATA|localhost:route_state_async_publish` (enabled by default).
+This is the remaining Redis bottleneck on orchagent's main thread. `ResponsePublisher` async offload moves APPL_STATE_DB writes, notifications, and recordings to a background thread, controlled by `SYSTEM_DEFAULTS|async_rec:status`.
 
 | What orchagent main thread does | All-Redis Default | ZMQ + Async Offload | End-state |
 |---|---|---|---|
@@ -265,11 +265,9 @@ Extend sonic-mgmt route performance tests to collect CPU and memory profiles dur
 **Goal:** Production deployment of ZMQ northbound + southbound with FIB suppression enabled.
 
 **Configuration knobs:**
-- ZMQ northbound: `orch_northbound_route_zmq_enabled = true`
-- ZMQ southbound: `orch_southbound_zmq_enabled = true`
+- ZMQ (northbound + southbound): `SYSTEM_DEFAULTS|swss_zmq:status = enabled`
 - FIB suppression: `suppress-fib-pending = enabled`
-- Async swss.rec logging: `async_swss_rec = enabled`
-- ResponsePublisher async offload: `route_state_async_publish = enabled`
+- Async recording + APPL_STATE_DB offload: `SYSTEM_DEFAULTS|async_rec:status = enabled`
 - Batch/bulk tuning: `-b` and `-k` optimized for deployment profile
 
 **Operational fixes:**


### PR DESCRIPTION
#### Why I did it

Update the route-performance strategy documentation to reflect the consolidation of 4 knobs from `DEVICE_METADATA|localhost` into 2 flat `SYSTEM_DEFAULTS` entries:

- `SYSTEM_DEFAULTS|swss_zmq` (status: enabled/disabled)
- `SYSTEM_DEFAULTS|async_rec` (status: enabled/disabled)

Companion PRs:
- sonic-swss: https://github.com/sonic-net/sonic-swss/pull/4630
- sonic-buildimage: https://github.com/sonic-net/sonic-buildimage/pull/27674
- sonic-sairedis: https://github.com/sonic-net/sonic-sairedis/pull/1922

#### How I did it

Updated `doc/route-performance/strategies/large-scale-datacenter-clos-fabric.md`:
- Changed config location from `DEVICE_METADATA|localhost` to flat `SYSTEM_DEFAULTS` list entries
- Consolidated `orch_northbond_route_zmq_enabled` + `orch_southbound_zmq_enabled` into `SYSTEM_DEFAULTS|swss_zmq`
- Consolidated `async_swss_rec` + `route_state_async_publish` into `SYSTEM_DEFAULTS|async_rec`

#### How to verify it

Documentation change only — verify content accuracy against the YANG model in the buildimage PR.
