### PR TITLE
[tsc/repo-maintainer]: Add maintainer roster and nomination process

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -87,3 +87,4 @@
 | sonic-host-services | Qi Luo(Microsoft) | qiluo-msft |  |
 | sonic-formal-infra | Mengqi Liu (Alibaba) | mengqiliu20 | enabled |
 |  | Ali Kheradmand (Google) | kheradmandG |enabled  |
+| sonic-redfish |  |  |  |

--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -1,0 +1,91 @@
+# SONiC Repo Maintainer Nomination - Voting Results
+
+| Repo | Maintainer Nominee | Github Id | Comments |
+|---|---|---|---|
+| sonic-ztp | Rajendra Dendukuri (Broadcom) | rajendra-dendukuri | enabled |
+| sonic-stp | Divya Chandralekha (Broadcom) | divyachandralekha | enabled |
+| sonic-dbsyncd | Storm Liang (Microsoft） | StormLiangMS | enabled |
+| sonic-dhcp-relay | Kelly Yeh (Microsoft) | kellyyeh | enabled |
+|  | Saikrishna Arcot (Microsoft) | saiarcot895 | enabled |
+|  | Propose add Jie Cai (Microsoft) - Nominated by Ying Xie | jcaiMR | enabled |
+|  | Ying Xie (Microsoft) | yxieca | enabled |
+| sonic-bmp | Syed Hasan Raza Naqvi (BRCM) | hasan-brcm | enabled |
+|  | Prince Sunny (Microsoft) | prsunny | enabled |
+|  | Sudharsan Dhamal Gopalarathnam (Nvidia) | dgsudharsan | enabled |
+|  | R, Gokulnath(DELL) reviewer | Gokulnath-Raja | enabled |
+| sonic-linkmgrd | Jing Zhang (Microsoft) | zjswhhh | enabled |
+|  | Longxiang Lyu (Microsoft) | lolyu | enabled |
+|  | Ying Xie (Microsoft) | yxieca | enabled |
+| sonic-linux-kernel | Saikrishna Arcot (Microsoft) | saiarcot895 | enabled |
+| sonic-mgmt-common | Kim, Kwan (DELL) | kwangsuk | enabled |
+|  | Shashank Neelam (Google) | sneelam20 | Replace Tomek on 3/5/2024 |
+|  | Anand Subramanian (BRCM) | anand-kumar-subramanian | approved on 5/3/2023 and enabled |
+| sonic-mgmt-framework | Joseph, Joyas (DELL) | joyas-joseph | enabled |
+|  | Shashank Neelam | sneelam20 | Replace Tomek on 3/5/2024 |
+|  | Anand Subramanian (BRCM) | anand-kumar-subramanian | Approved on 5/3/2023 and enabled |
+| sonic-pins | Bhagatram Janarthanan (Google) | bhagatgit | enabled |
+|  | Shitanshu Shah (Intel) | svshah-intel | removed on 11/14/2023 |
+|  | Brian O'Connor (Intel) | bocon13 | invitation sent |
+|  | Ravi Vantipalli (Intel) | ravi861 | enabled |
+|  | Kishan (Google) | kishanps | enabled |
+| sonic-platform-common | Prince George (Microsoft) | prgeor | enabled |
+|  | Mridul Bajpai (Cisco) | bmridul | enabled |
+|  | Kebo Liu (Nvidia) | keboliu | enabled |
+| sonic-platform-daemons | Prince George (Microsoft) | prgeor | enabled |
+|  | Mridul Bajpai (Cisco) | bmridul | enabled |
+|  | Kebo Liu (Nvidia) | keboliu | enabled |
+| sonic-platform-pdk-pde | Geans Pin (BRCM) | geans-pin | enabled |
+| sonic-py-swsssdk | Hua Liu (Microsoft) | liuh-80 | enabled |
+| sonic-restapi | Lawrence Lee (Microsoft) | theasianpianist | enabled |
+| sonic-sairedis | Kamil Cudnik (Microsoft) | kcudnik | added |
+|  | Junhua Zhai (Microsoft) | jimmyzhai | added |
+|  | Andriy Kokhan (Intel) | akokhan | enabled |
+|  | Volodymyr Boiko (Intel) | vboykox | enabled |
+|  | Kishore Gummadidala(Google) | erohsik | invitation sent |
+|  | Vishnu Shetty | vishnushetty | Approved on 5/3/2023 and enabled |
+| sonic-snmpagent | Suvarna Meenakshi (Microsoft) | SuvarnaMeenakshi | enabled |
+| sonic-swss | Guohan Lu (Microsoft) | lguohan | added |
+|  | Prince Sunny (Microsoft) | prsunny | added |
+|  | Marian Pritsak (Nvidia) | marian-pritsak | added |
+|  | Stephen Wang(Google) | StephenWangGoogle | enabled |
+|  | Laveen Thamilchelvam (BRCM) | LaveenBrcm | Approved on 5/3/2023 and enabled |
+|  | Rajesh Sankaran (BRCM) | srj102 | Approved on 5/3/2023 and enabled |
+| sonic-swss-common | Qi Luo (Microsoft) | qiluo-msft | eanbled |
+|  | Hua Liu (Microsoft) | liuh-80 | enabled |
+|  | Myron Sosyak (Intel) | msosyak | enabled |
+|  | Marian Pritsak (Nvidia) | marian-pritsak | enabled |
+|  | Runming Wu(Google) | mint570 | enabled |
+| sonic-gnmi (previously sonic-telemetry) | Qi Luo (Microsoft) | qiluo-msft | enabled |
+|  | Shashank Neelam | sneelam20 | Replace Tomek on 3/5/2024 |
+|  | Shishao (Alibaba) | shishao7sxm | invitation sent |
+|  | Seifert, Eric (DELL) reviewer | seiferteric | enabled |
+|  | Anand Subramanian (BRCM) | anand-kumar-subramanian | Approved on 5/3/2023 and enabled |
+| sonic-utilities | Qi Luo (Microsoft) | qiluo-msft | enabled |
+| sonic-wpa-supplicant | Ze Gan (Microsoft) | Pterosaur | enabled |
+| sonic-buildimage | Guohan Lu (Microsoft) | lguohan | enabled |
+|  | Ying Xie (Microsoft) | yxieca | enabled |
+|  | Kumaresh Perumal (Microsoft) | kperumalbfn | enabled |
+|  | Don Newton (Intel) | donNewtonIntel | enabled |
+|  | Yilan Ji (Google) | baxia-lan | enabled |
+|  | Praveen Elagala (BRCM) | Praveen-Brcm | Approved on 5/3/2023 and enabled |
+|  | Prasanth Veettil (BRCM) | Prasanth-KV | Approved on 5/3/2023 and enabled |
+| sonic-mgmt | Ying Xie (Microsoft) | yxieca | enabled |
+|  | Xin Wang (Microsoft) | wangxin | enabled |
+|  | Bhavani Parise (Cisco) | bpar9 | enabled |
+|  | John Cheung (Intel) | johcheun | invitation sent |
+|  | Myron Sosyak (Intel) | msosyak | enabled |
+|  | Vamsi Punati(Google) | vamsipunati | invitation sent |
+|  | Sasthri Kristipati (BRCM) | ramakristipati | Approved on 5/3/2023 and enabled |
+| sonic-fips | Xuhui Miao (Microsoft) | xumia | enabled |
+| sonic-genl-packet | Don Newton (Intel) | donNewtonIntel | enabled |
+| sonic-platform-vpp | Abdel Baig; Yue Gao (yuega2) | yue-fred-gao / abdbaig | enabled on 8/12/2024 per Cisco ask |
+|  | Bendrapu Balareddy (Cisco) | bendrapubalareddy | invitation sent |
+|  | Venkatesan Mahalingam (Dell) | venkatmahalingam | enabled |
+| sonic-dash-api | Ze Gan (Microsoft) | Pterosaur | enabled |
+| SONiC |  |  | enabled |
+| sonic-dash-ha | Riff Jiang (Microsoft) | r12f |  |
+| sonic-bmp | Feng Pan (Microsoft) | FengPan-Frank |  |
+|  | Qi Luo(Microsoft) | qiluo-msft | repo creation was approved by TSC on 3/28/2024 |
+| sonic-host-services | Qi Luo(Microsoft) | qiluo-msft |  |
+| sonic-formal-infra | Mengqi Liu (Alibaba) | mengqiliu20 | repo creation was approved by TSC on 5/15/2026 |
+|  | Ali Kheradmand (Google) | kheradmandG |  |

--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -1,6 +1,6 @@
-# SONiC Repo Maintainer Nomination - Voting Results
+# SONiC Repo Maintainer List
 
-| Repo | Maintainer Nominee | Github Id | Comments |
+| Repo | Maintainer | Github Id | Comments |
 |---|---|---|---|
 | sonic-ztp | Rajendra Dendukuri (Broadcom) | rajendra-dendukuri | enabled |
 | sonic-stp | Divya Chandralekha (Broadcom) | divyachandralekha | enabled |
@@ -58,7 +58,7 @@
 | sonic-gnmi (previously sonic-telemetry) | Qi Luo (Microsoft) | qiluo-msft | enabled |
 |  | Shashank Neelam | sneelam20 | Replace Tomek on 3/5/2024 |
 |  | Shishao (Alibaba) | shishao7sxm | invitation sent |
-|  | Seifert, Eric (DELL) reviewer | seiferteric | enabled |
+|  | Seifert, Eric (DELL) | seiferteric | enabled |
 |  | Anand Subramanian (BRCM) | anand-kumar-subramanian | Approved on 5/3/2023 and enabled |
 | sonic-utilities | Qi Luo (Microsoft) | qiluo-msft | enabled |
 | sonic-wpa-supplicant | Ze Gan (Microsoft) | Pterosaur | enabled |

--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -18,14 +18,13 @@
 |  | Ying Xie (Microsoft) | yxieca | enabled |
 | sonic-linux-kernel | Saikrishna Arcot (Microsoft) | saiarcot895 | enabled |
 | sonic-mgmt-common | Kim, Kwan (DELL) | kwangsuk | enabled |
-|  | Shashank Neelam (Google) | sneelam20 | Replace Tomek on 3/5/2024 |
-|  | Anand Subramanian (BRCM) | anand-kumar-subramanian | approved on 5/3/2023 and enabled |
+|  | Shashank Neelam (Google) | sneelam20 | enabled |
+|  | Anand Subramanian (BRCM) | anand-kumar-subramanian | enabled |
 | sonic-mgmt-framework | Joseph, Joyas (DELL) | joyas-joseph | enabled |
 |  | Shashank Neelam | sneelam20 | Replace Tomek on 3/5/2024 |
 |  | Anand Subramanian (BRCM) | anand-kumar-subramanian | Approved on 5/3/2023 and enabled |
 | sonic-pins | Bhagatram Janarthanan (Google) | bhagatgit | enabled |
-|  | Shitanshu Shah (Intel) | svshah-intel | removed on 11/14/2023 |
-|  | Brian O'Connor (Intel) | bocon13 | invitation sent |
+|  | Brian O'Connor (Google) | bocon13 | invitation sent |
 |  | Ravi Vantipalli (Intel) | ravi861 | enabled |
 |  | Kishan (Google) | kishanps | enabled |
 | sonic-platform-common | Prince George (Microsoft) | prgeor | enabled |
@@ -42,7 +41,7 @@
 |  | Andriy Kokhan (Intel) | akokhan | enabled |
 |  | Volodymyr Boiko (Intel) | vboykox | enabled |
 |  | Kishore Gummadidala(Google) | erohsik | invitation sent |
-|  | Vishnu Shetty | vishnushetty | Approved on 5/3/2023 and enabled |
+|  | Vishnu Shetty | vishnushetty | enabled |
 | sonic-snmpagent | Suvarna Meenakshi (Microsoft) | SuvarnaMeenakshi | enabled |
 | sonic-swss | Guohan Lu (Microsoft) | lguohan | added |
 |  | Prince Sunny (Microsoft) | prsunny | added |
@@ -78,14 +77,13 @@
 |  | Sasthri Kristipati (BRCM) | ramakristipati | Approved on 5/3/2023 and enabled |
 | sonic-fips | Xuhui Miao (Microsoft) | xumia | enabled |
 | sonic-genl-packet | Don Newton (Intel) | donNewtonIntel | enabled |
-| sonic-platform-vpp | Abdel Baig; Yue Gao (yuega2) | yue-fred-gao / abdbaig | enabled on 8/12/2024 per Cisco ask |
+| sonic-platform-vpp | Abdel Baig; Yue Gao (yuega2) | yue-fred-gaoabdbaig | enabled |
 |  | Bendrapu Balareddy (Cisco) | bendrapubalareddy | invitation sent |
 |  | Venkatesan Mahalingam (Dell) | venkatmahalingam | enabled |
 | sonic-dash-api | Ze Gan (Microsoft) | Pterosaur | enabled |
-| SONiC |  |  | enabled |
 | sonic-dash-ha | Riff Jiang (Microsoft) | r12f |  |
 | sonic-bmp | Feng Pan (Microsoft) | FengPan-Frank |  |
-|  | Qi Luo(Microsoft) | qiluo-msft | repo creation was approved by TSC on 3/28/2024 |
+|  | Qi Luo(Microsoft) | qiluo-msft | enabled |
 | sonic-host-services | Qi Luo(Microsoft) | qiluo-msft |  |
-| sonic-formal-infra | Mengqi Liu (Alibaba) | mengqiliu20 | repo creation was approved by TSC on 5/15/2026 |
-|  | Ali Kheradmand (Google) | kheradmandG |  |
+| sonic-formal-infra | Mengqi Liu (Alibaba) | mengqiliu20 | enabled |
+|  | Ali Kheradmand (Google) | kheradmandG |enabled  |

--- a/tsc/repo-maintainer/maintainer-nomination-process.md
+++ b/tsc/repo-maintainer/maintainer-nomination-process.md
@@ -35,7 +35,7 @@ A nominee may be put forward by **themselves, an existing maintainer of the repo
 
 ## Review & Approval
 
-1. Approval required by at least one existing maintainer approval and one TSC voting member.
+1. Approval required by at least one existing maintainer approval and two TSC voting members.
 2. There will be a two week window beginning upon opening of the PR, if there are no objections then the maintainership shall be approved.
 3. Approved entries are recorded in [SONiC_Repo_Maintainer.md](./SONiC_Repo_Maintainer.md).
 

--- a/tsc/repo-maintainer/maintainer-nomination-process.md
+++ b/tsc/repo-maintainer/maintainer-nomination-process.md
@@ -17,6 +17,10 @@ Maintainership is earned through sustained, high-quality contribution to the **s
 
 These map to the contribution categories used by the **SONiC Influence Index (SII)** in [TSC_Election.md](../TSC_Election.md). The SII categories are offered here as *guidance* for what "merit" looks like — there is no fixed SII score required to become a repo maintainer.
 
+## Responsibilities & Expectations
+- Code review - ensuring PRs align with components architecture and don't introduce breaking changes
+- Actively Triaging bugs
+
 ## How to Nominate
 
 A nominee may be put forward by **themselves, an existing maintainer of the repo, or a TSC member** (the roster records entries such as "Nominated by …").
@@ -31,8 +35,8 @@ A nominee may be put forward by **themselves, an existing maintainer of the repo
 
 ## Review & Approval
 
-1. The repo's existing maintainers and the TSC review the PR against the eligibility guidance above.
-2. Must be approved by all existing repo maintainers and majority of TSC members
+1. Approval required by at least one existing maintainer approval and one TSC voting member.
+2. There will be a two week window beginning upon opening of the PR, if there are no objections then the maintainership shall be approved.
 3. Approved entries are recorded in [SONiC_Repo_Maintainer.md](./SONiC_Repo_Maintainer.md).
 
 ## Onboarding

--- a/tsc/repo-maintainer/maintainer-nomination-process.md
+++ b/tsc/repo-maintainer/maintainer-nomination-process.md
@@ -36,7 +36,7 @@ A nominee may be put forward by **themselves, an existing maintainer of the repo
 ## Review & Approval
 
 1. Approval required by at least one existing maintainer approval and two TSC voting members.
-2. There will be a two week window beginning upon opening of the PR, if there are no objections then the maintainership shall be approved.
+2. There will be a four week window beginning upon opening of the PR, if there are no objections then the maintainership shall be approved.
 3. Approved entries are recorded in [SONiC_Repo_Maintainer.md](./SONiC_Repo_Maintainer.md).
 
 ## Onboarding

--- a/tsc/repo-maintainer/maintainer-nomination-process.md
+++ b/tsc/repo-maintainer/maintainer-nomination-process.md
@@ -1,0 +1,53 @@
+# SONiC Repo Maintainer Nomination Process
+
+A lightweight guideline for nominating and onboarding a maintainer for a SONiC repository. It complements the maintainer roster in [SONiC_Repo_Maintainer.md](./SONiC_Repo_Maintainer.md), the project [governance model](../../governance.md).
+
+## Roles
+
+- **Maintainer** — has merge rights to a repository's `master`/`main` branch and is accountable for its quality and direction. 
+
+## Eligibility (guidance)
+
+Maintainership is earned through sustained, high-quality contribution to the **specific repository**, in keeping with SONiC's meritocracy principle. Strong signals include:
+
+- A track record of merged PRs in the repo.
+- Consistent, helpful PR reviews.
+- Authored or reviewed High Level Designs (HLDs) for the repo's domain.
+- Demonstrated domain expertise and reliable responsiveness.
+
+These map to the contribution categories used by the **SONiC Influence Index (SII)** in [TSC_Election.md](../TSC_Election.md). The SII categories are offered here as *guidance* for what "merit" looks like — there is no fixed SII score required to become a repo maintainer.
+
+## How to Nominate
+
+A nominee may be put forward by **themselves, an existing maintainer of the repo, or a TSC member** (the roster records entries such as "Nominated by …").
+
+1. Create a new PR against [SONiC_Repo_Maintainer.md](./SONiC_Repo_Maintainer.md).
+2. Include:
+   - Name
+   - Organization
+   - GitHub ID
+   - Target repository
+   - A brief justification of the nominee's contributions to that repo (links to PRs, reviews, or HLDs are encouraged).
+
+## Review & Approval
+
+1. The repo's existing maintainers and the TSC review the PR against the eligibility guidance above.
+2. The TSC approves the nomination. Approved entries are recorded in [SONiC_Repo_Maintainer.md](./SONiC_Repo_Maintainer.md).
+
+## Onboarding
+
+Once approved:
+
+1. A GitHub access invitation is sent to the new maintainer — the roster reflects this as `invitation sent`, then `enabled` once accepted.
+3. Record the new entry in [SONiC_Repo_Maintainer.md](./SONiC_Repo_Maintainer.md) (repo, name, GitHub ID, status).
+
+## Stepping Down, Removal, and Replacement
+
+- A maintainer may step down voluntarily at any time; the maintainer should create a new PR against [SONiC_Repo_Maintainer.md](./SONiC_Repo_Maintainer.md) with removal request
+- The TSC review the PR and approve
+
+## References
+
+- [Project Governance](../../governance.md)
+- [TSC Election Process](../TSC_Election.md)
+- [SONiC Repo Maintainer Roster](./SONiC_Repo_Maintainer.md)

--- a/tsc/repo-maintainer/maintainer-nomination-process.md
+++ b/tsc/repo-maintainer/maintainer-nomination-process.md
@@ -1,4 +1,4 @@
-# SONiC Repo Maintainer Nomination Process
+# SONiC Repo Maintainer Process
 
 A lightweight guideline for nominating and onboarding a maintainer for a SONiC repository. It complements the maintainer roster in [SONiC_Repo_Maintainer.md](./SONiC_Repo_Maintainer.md), the project [governance model](../../governance.md).
 
@@ -32,7 +32,8 @@ A nominee may be put forward by **themselves, an existing maintainer of the repo
 ## Review & Approval
 
 1. The repo's existing maintainers and the TSC review the PR against the eligibility guidance above.
-2. The TSC approves the nomination. Approved entries are recorded in [SONiC_Repo_Maintainer.md](./SONiC_Repo_Maintainer.md).
+2. Must be approved by all existing repo maintainers and majority of TSC members
+3. Approved entries are recorded in [SONiC_Repo_Maintainer.md](./SONiC_Repo_Maintainer.md).
 
 ## Onboarding
 


### PR DESCRIPTION
#### Why I did it
The `tsc/repo-maintainer/` folder previously had no checked-in content describing who maintains each SONiC repository or how a contributor becomes a maintainer. This PR adds that documentation in one place.

#### What I did
Added two documents under `tsc/repo-maintainer/`:
- **`SONiC_Repo_Maintainer.md`** — per-repository maintainer/reviewer roster with status (enabled, invitation sent, approved, reviewer, etc.).
- **`maintainer-nomination-process.md`** — a lightweight guideline for nominating and onboarding a repo maintainer (roles, eligibility guidance referencing the SII from `tsc/TSC_Election.md`, nomination → review/approval → onboarding, and stepping down/removal). Cross-links to `governance.md`, `tsc/TSC_Election.md`, and the roster.

Documentation only — no code changes.

#### How to verify it
- Both Markdown files render correctly.
- Relative links resolve from `tsc/repo-maintainer/`: `../../governance.md`, `../TSC_Election.md`, `./SONiC_Repo_Maintainer.md`.

#### Which release branch to backport (provide reason below if selected)
None — documentation/governance change, master only.
