### PR TITLE
leakage detection db schema update

### DIFF
--- a/doc/bmc/leakage_detection_hld.md
+++ b/doc/bmc/leakage_detection_hld.md
@@ -102,7 +102,8 @@ Defines a logical structure for liquid cooling devices, with keys for various se
 key                       = LIQUID_COOLING_DEVICE|leakage_sensors{X}
  ; field                  = value
 name                      = STR     ; sensor name
-leaking                   = STR     ; Yes or No to indicate leakage status
+leaking                   = STR     ; 1 or 0 to indicate leakage status
+leak_status               = STR     ; Covert leaking 1/0 to yes/no, default as N/A to prevent sensor not readable
 ```
 
 ## 6. system health monitor


### PR DESCRIPTION
since the implementation used leak_status field to covert the leaking value, either 1 or 0 to user friendly Yes and No. Besides, the default value of it is N/A, so it prevents in some case when leak sensor is not readable due to hardware failure, user will get the exact information.