### PR TITLE
docs: Add HLD for Bazel migration

### DIFF
--- a/doc/bazel/bazel_migration_hdl.md
+++ b/doc/bazel/bazel_migration_hdl.md
@@ -1,0 +1,272 @@
+# SONiC Build System Migration #
+
+## Table of Content 
+
+### 1. Revision  
+
+### 2. Scope  
+
+This document covers the migration of the SONiC build system into a modern, Bazel-based system. It proposes an end state of the build system, as well as a migration path to get us there.
+
+### 3. Definitions/Abbreviations 
+
+- Bazel: A build system open-sourced by Google. It specializes in polyglot builds, and promises fast, reproducible builds through hermeticity. [Documentation](https://bazel.build/docs)
+- Bazel rules, also called rulesets: Extensions to Bazel to provide additional capabilities, usually to integrate Bazel with a new programming language. Usually named `rules_<lang>`. For instance, `rules_go` extends Bazel to be able to build and test Go sources. [Documentation](https://bazel-docs-staging.netlify.app/versions/master/skylark/rules.html)
+- BUILD files: Files where the Bazel build is defined. Usually named `BUILD.bazel`, and written by hand in [Starlark](TODO BL: link to docs). [Documentation](https://bazel.build/concepts/build-files)
+- Bazel registry: A specially-shaped directory that hosts bazel rules and their versions. [Documentation](https://bazel.build/external/registry)
+- Bazel Central Registry, or BCR: The canonical, Google-maintained Bazel registry. Most rulesets live here, and most Bazel projects pull their rulesets from here. [Documentation](https://registry.bazel.build/)
+- bzlmod: Bazel's dependency resolution tool, which takes care of resolving ruleset dependencies. Automatically works with the BCR by default, but can be configured to resolve dependencies from other Bazel registries. [Documentation](https://bazel.build/external/overview)
+- Bazel target: The unit of a build. A target represents one or more inputs and produces one or more outputs. For instance, "the docker image for syncd" is a target, but so is "the shared library of sonic_swss_common". [Documentation](https://bazel.build/concepts/build-ref)
+- Label: The unique identifier of a target. It follows the syntax `@<repository name>//path/to/target:<target name>` . For instance, `@sonic_buildimage//dockers/docker-base-bookworm:docker-base-bookworm` refers to [this target](https://github.com/thesayyn/sonic-buildimage/blob/04f2d3bf54650b1ceecb663a11f53be6810856f1/dockers/docker-base-bookworm/BUILD.bazel#L123-L139). [Documentation](https://bazel.build/concepts/labels)
+
+Non-Bazel Definitions
+- debhelper, or `dh`: A suite of Debian tools to rebuild and repack Debian packages. In SONiC, they are used to apply patches to external dependencies. [Documentation](https://man7.org/linux/man-pages/man1/dh.1.html)
+- Open Container Initiative (OCI): An industry standard to specify container formats and runtimes. [Documentation](https://opencontainers.org/).
+
+#### 3.a Prior Art
+
+We have already implemented large parts of this document as proofs of concept.
+
+Please see these publications about our work:
+- Talk from OCP EMEA Summit 2026: https://www.youtube.com/watch?v=uSKCNDWuXjc
+- Blog article about our work:  https://aspect.build/blog/bazel-for-sonic
+
+### 4. Overview 
+
+#### 4.a Motivation
+
+The current SONiC build system, while being ergonomic and accommodating the vast matrix of platforms and vendors that are required, has some shortcomings, that the community has been feeling for some time.
+
+After two decades of SONiC development, we now have a fuller picture of what SONiC needs in a build. With this information, we believe we can build a faster, more reliable build system on top of Bazel.
+
+Early results demonstrate that we can produce cold builds similar to those in the current system, but **sub-minute builds** for some classes of incremental changes, all while keeping hermeticity and reproducibility, so that the same build on the same commit will produce the same results a year from now.
+
+// TODO BL: Should we include a table here?
+
+#### 4.b Migration Overview
+
+Bazel migrations are expensive, and famously disruptive. To alleviate this issue as much as possible, we propose a gradual rollout. We will migrate each component in turn, in a manner such that we:
+
+- Keep compatibility with the old build system. A component built with Bazel can be depended on from a component built with Make.
+- Can roll back if needed. The old build system will remain in place, even for migrated components, to ensure users can roll back quickly if there are issues.
+
+### 5. Requirements
+
+TODO BL: I need to read more what they expect here.
+
+### 6. Architecture Design 
+
+This section covers the changes that are required in the SONiC architecture. In general, it is expected that the current architecture is not changed.
+This section should explain how the new feature/enhancement (module/sub-module) fits in the existing architecture. 
+
+If this feature is a SONiC Application Extension mention which changes (if any) needed in the Application Extension infrastructure to support new feature.
+
+### 7. High-Level Design 
+
+This section specifies how different parts of the build will work under Bazel. Everything explained here has already been implemented in a proof of concept, in [thesayyn/sonic-buildimage](https://github.com/thesayyn/sonic-buildimage).
+
+#### 7.a Groundwork
+
+The Bazel ethos is that **every input to a build must be known, down to the checksum, before the build starts**. The current build system has a few instances where we cannot deterministically predict these inputs.
+
+- Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](TODO LINK to sonic-build-infra/toolchain).
+- Fetch Debian packages deterministically, instead of relying in `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](TODO BL: Source to code in sonic-buildimage that pulls this stuff).
+- For components that have Python dependencies, we created `pyproject.toml` files to be able to generate deterministic `uv` lockfiles. [Example](TODO BL: Example for sonic-utilities).
+
+#### 7.b Managing Patched External Dependencies
+
+The SONiC build relies on patching several third party dependencies (e.g. [libnl3](TODO BL: link to buildimage/src/libnl3)). Furthermore, it relies on the Debian suite of tools ([debhelper](https://man7.org/linux/man-pages/man1/dh.1.html) and associated tools), which is not compatible with Bazel. Hence, another solution is required.
+
+We propose four approaches to tackle this problem. They are detailed in [this PR to `thesayyn/sonic-buidimage`](https://github.com/thesayyn/sonic-buildimage/pull/15), but we will list their summaries here for ease of reference.
+
+In order of most preferred to least preferred, they are:
+
+1. Find the module we want to patch in the BCR. Please see the PR for instructions on how to patch it.
+2. Pull the dependency as a Debian package with `rules_distroless`. This method does not allow patching.
+3. Migrate said dependency to Bazel. The specific method will depend on the dependency, but tips and tricks have been listed in the document above.
+4. Patch and build the dependency out of band, and then import the built artifacts into the Bazel build.
+
+#### 7.c Building Component Containers
+
+Currently, most components in SONiC are bundled into `.deb` archives before being installed in the containers to be deployed.
+
+We propose a similar model except, instead of `.deb` archives, we will bundle the components into tar archives for ease of consumption. Using `tar.bzl` and `mtree`, we can replicate the rootfs structure of `.deb` packages:
+
+```starlark
+# Example from: https://github.com/thesayyn/sonic-buildimage/blob/master/src/sonic-sysmgr/BUILD.bazel#L4-L11
+# Note how we're able to place a file in `/debian/sysmgr/rebootbackend`.
+tar(
+    name = "sysmgr_pkg",
+    srcs = ["//rebootbackend"],
+    mtree = [
+        "./debian/sysmgr/rebootbackend type=file content=$(location //rebootbackend:rebootbackend)",
+    ],
+    visibility = ["//visibility:public"],
+)
+```
+
+Then, we can skip the `apt install` step of building containers and just treat each tar as an OCI container layer with `rules_oci`:
+
+```starlark
+# Example from: https://github.com/thesayyn/sonic-buildimage/blob/master/dockers/docker-base-bookworm/BUILD.bazel#L123-L139
+oci_image(
+    name = "docker-base-bookworm",
+    architecture = "amd64",
+    entrypoint = ["/usr/bin/supervisord"],
+    env = {
+        "DEBIAN_FRONTEND": "noninteractive",
+    },
+    os = "linux",
+    tars = [ # Each of these is a tar() target.
+        ":rootfs",
+        ":rootdirslinks",
+        ":flat",
+        ":site-packages",
+        "@sonic_supervisord_utilities//:dist",
+    ],
+    visibility = ["//visibility:public"],
+)
+```
+
+#### 7.d Platform & Device Support
+
+The current SONiC build supports a rich matrix of vendors, platforms, and devices. This can be replicated with Bazel's expressive configuration language.
+
+We define command line flags to allow users to specify which device and ASIC manufacturer they're targeting ([link](https://github.com/thesayyn/sonic-build-infra/blob/master/config/BUILD.bazel)):
+
+```starlark
+# SONiC platform, which maps to ASIC manufacturers
+string_flag(
+    name = "asic_manufacturer",
+    build_setting_default = "_incompatible",
+    values = [
+	    "broadcom",
+	    "marvell-prestera",
+	    ... # Other manufacturers
+	],
+)
+```
+
+Then, we can use these values to parameterize the build. For instance, we can define an alias at `@sonic_buildimage//dockers/docker-syncd` that will point to the right `@sonic_buildimage//platform` subdirectory:
+
+```starlark
+# Will resolve to the right docker image based on platform, or fail if no platform is specified or if the specified platform is not supported.
+
+alias(
+    name = "docker-syncd",
+    actual = select({
+        "@sonic_build_infra//config:platform_vs": "//platform/vs/docker-syncd-vs",
+        "@sonic_build_infra//config:platform_broadcom": "//platform/broadcom/docker-syncd-brcm",
+        "//conditions:default": ":empty",
+    }),
+)
+```
+
+Once the build is defined like that, a user that wants to build for Broadcom can specify this from the command line:
+
+```shell
+$ bazel build //dockers/docker-syncd:docker-syncd --@sonic_build_infra//asic_manufacturer=broadcom
+```
+
+We can similarly parameterize every aspect of the build, including which SAI implementation to use:
+
+```shell
+$ bazel build <target> \
+   --@sonic_build_infra//asic_manufacturer=broadcom
+   --@sonic_build_infra//sai=<your custom SAI implementation>
+```
+
+For ease of use, we propose bundling default configurations for well-known combinations:
+
+```shell
+$ bazel build <target> --config=broadcom # Equivalent to the above.
+```
+
+#### 7.e Debuggability
+
+We will implmement automatic debug container generation, mirroring the current system.
+
+We will write a Bazel rule that will crawl the dependency tree of an image, capture the debug symbols of its binaries, and bundle them with well-known debugging tools such as `gdb` to create debug containers.
+
+For instance, following the example in [7.d](TODO BL: LINK):
+
+```starlark
+oci_image(
+    name = "docker-base-bookworm",
+    ...
+)
+
+debug_container(
+	name = "docker-base-bookworm_dbg",
+    base = ":docker-base-bookworm" # reference the container above
+)
+```
+
+Users will then be able to load these containers into switches normally for debugging.
+
+#### 7.f Affected Systems
+
+##### Dependency Changes
+
+We lose a few dependencies:
+- We no longer need a sonic-slave container.
+- We no longer depend on developer tools such as `gcc` and `python` being installed in the build machine.
+- We no longer depend on Docker at build time.
+
+And we gain a few dependencies:
+- We depend on Google servers to download and install Bazel at build time.
+- We gain a dependency on the Bazel Central Registry.
+
+##### Changed Repositories
+
+Every component repository will need to be migrated to Bazel. `sonic-buildimage` will also need to change, but it will be migrated piecemeal.
+
+#### 7.g Performance Summary
+
+We expect the resulting containers to be comparable (if not equal) to those produced by the old build system, both in terms of size and runtime performance and memory footprint.
+
+We aim for build times to be reduced dramatically, especially for incremental builds. We expect noticeable second-order effects on developer ergonomics, as a more reliable build means fewer cold builds overall. We expect on-disk build caches to be significantly larger than those of the old build system.
+
+### 8. SAI API 
+
+There are no changes to the SAI API.
+
+### 9. Configuration and management 
+
+There are no changes to the configuration.
+
+### 10. Warmboot and Fastboot Design Impact  
+
+TODO BL: I probably need help from Brian for this
+
+### Warmboot and Fastboot Performance Impact
+This sub-section must cover the impact of the functionality on warmboot and fastboot performance, that is control plane and data plane downtime.
+As part of the analysis cover the flowing:
+
+- Does this feature add any stalls/sleeps/IO operations to the boot critical chain? Does it change when this feature is disabled/unused? 
+- Does this feature add any additional CPU heavy processing (e.g. rendering Jinja templates) in the boot path (process, library or utility used during boot up)? Does it change when this feature is disabled/unused?
+- In case this feature updates a third party dependency does it cause any impact on boot time performance?
+- Can the feature (service or docker) be delayed?
+- What are the possible optimizations and what is the expected boot time degradation if, by the nature of the feature, additional CPU/IO costs can't be avoided?
+
+### 11. Memory Consumption
+
+We expect the resulting containers to be comparable (if not equal) to those produced by the old build system, both in terms of size and runtime performance and memory footprint.
+
+### 12. Restrictions/Limitations  
+
+We should not depend on the host system at all. This means that we must find hermetic alternatives to historically unhermetic software, such as gcc. For instance, we should never rely on gcc being installed on the system.
+
+This means that, sometimes, we'll need to migrated dependencies to Bazel, which incurs a non-trivial cost. A large portion of these dependencies have already been migrated, and the maintenance cost is estimated to be low.
+
+### 13. Testing Requirements/Design  
+
+// TODO BL: I probably need Brian's help for this, since his team has been donig the validation
+
+#### 13.1. Unit Test cases  
+
+#### 13.2. System Test cases
+
+### 14. Open/Action items - if any 
+
+ // TODO BL:

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -30,12 +30,9 @@
 8. [SAI API](#8-sai-api)
 9. [Configuration and management](#9-configuration-and-management)
 10. [Warmboot and Fastboot Design Impact](#10-warmboot-and-fastboot-design-impact)
-    - [Warmboot and Fastboot Performance Impact](#warmboot-and-fastboot-performance-impact)
 11. [Memory Consumption](#11-memory-consumption)
 12. [Restrictions/Limitations](#12-restrictionslimitations)
 13. [Testing Requirements/Design](#13-testing-requirementsdesign)
-    - [13.1. Unit Test cases](#131-unit-test-cases)
-    - [13.2. System Test cases](#132-system-test-cases)
 14. [Open/Action items - if any](#14-openaction-items---if-any)
 
 ### 1. Revision

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -112,9 +112,9 @@ All components should still be buildable with the regular Make-based flow.
 
 When a component is built with Bazel, this will entail:
 
-- Eliminating system dependencies (e.g. from `apt` and `whl`), as well as other sonic-make injected deps. All dependencies will go through the hermetic Bazel build graph.
-- Removing `deb` packages as an intermediate format, instead relying on the Bazel dependency graph.
-- Removing `docker` as a dependency, instead building containers directly with Bazel.
+- Eliminating system dependencies for that component (e.g. from `apt` and `whl`), as well as other sonic-make injected deps. All dependencies will go through the hermetic Bazel build graph.
+- Removing `deb` packages as an intermediate format for that component, instead relying on the Bazel dependency graph.
+- Removing `docker` as a dependency for that component, instead building containers directly with Bazel.
 
 However, we will not attempt to:
 
@@ -141,13 +141,13 @@ This will signal to the community that we do intend to adopt Bazel, and that the
 
 By turning `BUILD_WITH_BAZEL_WHEN_AVAILABLE` on, we'll also be making the Bazel build **blocking in CI**. As a consequence, any changes that break the Bazel build will have to be fixed before they're merged.
 
-It is possible that, at this point, the need arises for a per-target toggle. This is left as an [open question](#14-openaction-items---if-any).
+It is possible that, at this point, the need arises for a per-component Bazel toggle. This is left as an [open question](#14-openaction-items---if-any).
 
 We expect to increase coverage of targets that build with Bazel. Specifically, we'll transition to building the base layers (`docker-base-*`, `docker-config-engine-*`, and `docker-swss-layer-*`) with Bazel by default.
 
 By the end of this phase, we expect most users to be able to build their components entirely in Bazel, without the need of a slave container.
 
-**This opt-out window will only exist for 1 release. After that, we will move into Phase 3.**
+**This opt-out window will only exist for 1 release after the Bazel build for a component has been introduced. After that, we will move into Phase 3.**
 
 ##### Phase 3: Bazel-only
 
@@ -161,8 +161,8 @@ One open question is when we will establish a blocking CI pipeline for Bazel bui
 
 We propose the following structure:
 
-- Phase 1: A nightly, post-merge job that tests the Bazel builds only. There are no expectations to keep this job green.
-- Phase 2: At the start of Phase 2, the components that are migrated to Bazell will now be blocking pre-merge, as we flip the default of `BUILD_WITH_BAZEL_WHEN_AVAILABLE`.
+- Phase 1: A nightly, post-merge job that tests the Bazel builds only. There are no expectations to keep this job green, but it will be useful in spotting regressions.
+- Phase 2: Bazel builds are blocking pre-submit. When we flip the default of `BUILD_WITH_BAZEL_WHEN_AVAILABLE`, the components that are migrated to Bazell will now be blocking the pre-submit checks.
 
 This phased approach allows us to establish critical infrastructure and let the build mature before we make it required for anyone.
 

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -8,6 +8,8 @@
 
 This document covers the migration of the SONiC build system into a modern, Bazel-based system. It proposes an end state of the build system, as well as a migration path to get us there.
 
+Please note that this design covers only the migration of individual components. Migrating the full image assembly process is out of the scope of this document.
+
 ### 3. Definitions/Abbreviations 
 
 - Bazel: A build system open-sourced by Google. It specializes in polyglot builds, and promises fast, reproducible builds through hermeticity. [Documentation](https://bazel.build/docs)
@@ -43,12 +45,60 @@ Early results demonstrate that we can produce cold builds similar to those in th
 
 // TODO BL: Should we include a table here?
 
-#### 4.b Migration Overview
+#### 4.b Migration
 
-Bazel migrations are expensive, and famously disruptive. To alleviate this issue as much as possible, we propose a gradual rollout. We will migrate each component in turn, in a manner such that we:
+Bazel migrations are expensive, and famously disruptive. To alleviate this issue as much as possible, we propose a gradual, non-mandatory rollout.
 
-- Keep compatibility with the old build system. A component built with Bazel can be depended on from a component built with Make.
-- Can roll back if needed. The old build system will remain in place, even for migrated components, to ensure users can roll back quickly if there are issues.
+We will migrate each component in turn, starting from the components that are depended on the least.
+For each component, we will introduce the Bazel build for its container, while retaining the ability to build the container with the current system.
+Users can control whether they want to build with Bazel or GNU make with a command line flag:
+
+```
+$ make build // TODO BL: Current command
+$ BUILD_WITH_BAZEL_WHEN_AVAILABLE=true make build  // TODO BL: Current command
+```
+
+This flag will start off by default. The implementation of this flag's semantics is defined in [TODO BL:](section 7.h).
+
+To minimize disruption, we propose the following phases to the migration:
+
+##### Phase 1: Opt-in trial period
+
+Phase 1 will introduce Bazel as an optional build system for some components. For this phase, `BUILD_WITH_BAZEL_WHEN_AVAILABLE` will be turned off by default.
+We will start with small components such as `sflow`, `teamd`, and `database`, and continue onto progressively larger leaf components until we have sufficient coverage to be representative of the Bazel build.
+We expect this phase to last until the November release.
+
+The community can use this period to experiment with Bazel, adopt it into their own builds, and generally gather information on whether this is a net benefit.
+
+After the November release, the community will face a decision point: Should we adopt Bazel fully?
+
+If we decide to move forward, we will continue onto Phase 2.
+
+##### Phase 2: Opt-out migration period
+
+At the start of this phase, we will flip `BUILD_WITH_BAZEL_WHEN_AVAILABLE` to be on by default.
+This will signal to the community that we do intend to adopt Bazel, and that they should start adopting it into their internal forks if they haven't already.
+
+We expect to massively increase coverage of targets that build with Bazel, specifically extending to building the base layers (`docker-base-*`, `docker-config-engine-*`, and `docker-swss-layer-*`) with Bazel by default.
+
+By the end of this phase, we expect most users to be able to build their components entirely in Bazel, without the need of a slave container.
+
+##### Phase 3: Bazel-only
+
+When every component can be built with Bazel, and most users have had a reasonable opportunity to migratie, we expect to be able to remove the current build system, and transition to using exclusively Bazel.
+
+We cannot give estimations of when this will be, as it will depend on community support and involvement.
+
+##### CI considerations
+
+One open question is when we will establish a blocking CI pipeline for Bazel builds.
+We propose doing this early, as part of Phase 1.
+
+After the first container build merges, we will stand up a non-blocking CI pipeline that will test the Bazel build.
+That pipeline will run on every build, but failures in it won't block contributors from merging code.
+
+When that pipeline has been proven to be stable for a reasonable period, we propose to make it blocking, so that contributions that would break the Bazel build cannot be merged.
+This will avoid code drift between the two builds, helping tremendously with migration speed.
 
 ### 5. Requirements
 
@@ -56,10 +106,7 @@ TODO BL: I need to read more what they expect here.
 
 ### 6. Architecture Design 
 
-This section covers the changes that are required in the SONiC architecture. In general, it is expected that the current architecture is not changed.
-This section should explain how the new feature/enhancement (module/sub-module) fits in the existing architecture. 
-
-If this feature is a SONiC Application Extension mention which changes (if any) needed in the Application Extension infrastructure to support new feature.
+There are no expected changes to the SONiC architecture.
 
 ### 7. High-Level Design 
 
@@ -226,6 +273,16 @@ Every component repository will need to be migrated to Bazel. `sonic-buildimage`
 We expect the resulting containers to be comparable (if not equal) to those produced by the old build system, both in terms of size and runtime performance and memory footprint.
 
 We aim for build times to be reduced dramatically, especially for incremental builds. We expect noticeable second-order effects on developer ergonomics, as a more reliable build means fewer cold builds overall. We expect on-disk build caches to be significantly larger than those of the old build system.
+
+#### 7.h Bazel/make interoperability
+
+During the migration, Bazel and make will have to interoperate. We propose a model where we introduce top-level make targets for Bazel-compatible containers.
+
+// TODO BL: Fill out with code examples
+
+Some other considerations:
+- Bazel should consume layers built by make.
+- Bazel would execute inside the slave container for now. There are still hermeticity issues in the Bazel build, so it does end up depending on the host system. Therefore, to ensure interoperability with the make-built layers, we'll build in the slave container. These hermeticity issues should be treated as bugs, but in the interest of getting the build in the hands of users we choose to solve them later in the migration.
 
 ### 8. SAI API 
 

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -16,16 +16,16 @@
 5. [Requirements](#5-requirements)
 6. [Architecture Design](#6-architecture-design)
 7. [High-Level Design](#7-high-level-design)
-   - [7.a Groundwork](#7a-groundwork)
-   - [7.b Managing Patched External Dependencies](#7b-managing-patched-external-dependencies)
-   - [7.c Building Component Containers](#7c-building-component-containers)
-   - [7.d Platform & Device Support](#7d-platform--device-support)
-   - [7.e Debuggability](#7e-debuggability)
-   - [7.f Affected Systems](#7f-affected-systems)
+   - [7.a Bazel/make interoperability](#7a-bazelmake-interoperability)
+   - [7.b Groundwork](#7b-groundwork)
+   - [7.c Managing Patched External Dependencies](#7c-managing-patched-external-dependencies)
+   - [7.d Building Component Containers](#7d-building-component-containers)
+   - [7.e Platform & Device Support](#7e-platform--device-support)
+   - [7.f Debuggability](#7f-debuggability)
+   - [7.g Affected Systems](#7g-affected-systems)
      - [Dependency Changes](#dependency-changes)
      - [Changed Repositories](#changed-repositories)
-   - [7.g Performance Summary](#7g-performance-summary)
-   - [7.h Bazel/make interoperability](#7h-bazelmake-interoperability)
+   - [7.h Performance Summary](#7h-performance-summary)
 8. [SAI API](#8-sai-api)
 9. [Configuration and management](#9-configuration-and-management)
 10. [Warmboot and Fastboot Design Impact](#10-warmboot-and-fastboot-design-impact)
@@ -70,6 +70,10 @@ Please see these publications about our work:
 
 ### 4. Overview 
 
+> [!tip]
+> A full example of migrating a container can be found in [sonic-buildimage#28005](https://github.com/sonic-net/sonic-buildimage/pull/28005).
+> We will explore the different moving pieces in that PR in [Section 7](7-high-level-design).
+
 #### 4.a Motivation
 
 The current SONiC build system, while being ergonomic and accommodating the vast matrix of platforms and vendors that are required, has some shortcomings, that the community has been feeling for some time.
@@ -78,14 +82,13 @@ After two decades of SONiC development, we now have a fuller picture of what SON
 
 Early results demonstrate that we can produce cold builds similar to those in the current system, but **sub-minute builds** for some classes of incremental changes, all while keeping hermeticity and reproducibility, so that the same build on the same commit will produce the same results a year from now.
 
-// TODO BL: Should we include a table here?
-
 #### 4.b Migration
 
 Bazel migrations are expensive, and famously disruptive. To alleviate this issue as much as possible, we propose a gradual, non-mandatory rollout.
 
-We will migrate each component in turn, starting from the components that are depended on the least.
-For each component, we will introduce the Bazel build for its container, while retaining the ability to build the container with the current system.
+We will extend the existing build system with a new target type that can build docker containers in Bazel.
+The mechanics of this new target are discussed in [7.a](#7a-bazelmake-interoperability).
+
 Users can control whether they want to build with Bazel or GNU make with a command line flag:
 
 ```
@@ -96,7 +99,7 @@ $ BUILD_WITH_BAZEL_WHEN_AVAILABLE=true make target/docker-sysmgr.gz
 # make runs Bazel to build the target
 ```
 
-This flag will start off by default. The implementation of this flag's semantics is defined in [section 7.h](#7h-bazelmake-interoperability).
+This flag will start off by default. The implementation of this flag's semantics is defined in [section 7.a](#7a-bazelmake-interoperability).
 
 To minimize disruption, we propose the following phases to the migration:
 
@@ -168,21 +171,87 @@ There are no expected changes to the SONiC architecture.
 
 ### 7. High-Level Design 
 
-This section specifies how different parts of the build will work under Bazel. Everything explained here has already been implemented in a proof of concept, in [thesayyn/sonic-buildimage](https://github.com/thesayyn/sonic-buildimage).
+This section specifies how different parts of the build will work under Bazel.
+Everything explained here has already been implemented in a proof of concept migrating `docker-sysmgr`, in [sonic-buildimage#28005](https://github.com/sonic-net/sonic-buildimage/pull/28005).
+The following sections will explain different parts of that PR.
 
-#### 7.a Groundwork
+#### 7.a Changes to Existing Build System (Bazel/make Interoperability)
+
+During the migration, Bazel and make will have to interoperate. This section explains the changes needed in the current build system to make that happen.
+
+We propose to **extend the existing build system to add the ability to build some targets with Bazel**. For example, with [docker-sysmgr](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/rules/docker-sysmgr.mk#L21-L30):
+
+```make
+# From sonic-buildimage#28005/rules/docker-sysmgr.mk
+
+...
+ifeq ($(BUILD_WITH_BAZEL_WHEN_AVAILABLE),n)
+
+SONIC_DOCKER_IMAGES += $(DOCKER_SYSMGR)
+SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_SYSMGR)
+
+else
+
+# When BUILD_WITH_BAZEL_WHEN_AVAILABLE is enabled, build this docker with Bazel.
+# Bazel only supports bookworm today, which is enforced at the root Makefile.
+$(DOCKER_SYSMGR)_BAZEL_BASE += $(DOCKER_CONFIG_ENGINE_BOOKWORM)
+SONIC_BAZEL_DOCKER_IMAGES += $(DOCKER_SYSMGR)
+SONIC_BOOKWORM_DOCKERS += $(DOCKER_SYSMGR)
+
+endif
+...
+```
+
+As shown in the example, the `BUILD_WITH_BAZEL_WHEN_AVAILABLE` configuration flag will toggle the entire Bazel behaviour. When switched off, the system will use the regular make-based build:
+
+```make
+# From sonic-buildimage#28005/rules/config
+
+...
+# Build eligible dockers (those registered in SONIC_BAZEL_DOCKER_IMAGES) with
+# Bazel instead of the legacy `docker build` flow.
+# When disabled, fall back to the normal Make docker build.
+BUILD_WITH_BAZEL_WHEN_AVAILABLE ?= n
+```
+
+This flag is defined in [rules/config](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/rules/config#L164-L177), along with another flag to control where the Bazel cache directory goes, `SONIC_BAZEL_CACHE_SOURCE`.
+
+We modify the rules execution engine to create targets for this new target type. In [`slave.mk`](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/slave.mk#L1413-L1420):
+
+```make
+# From sonic-buildimage#28005/slave.mk
+
+...
+# Targets for building docker images with Bazel.
+$(addprefix $(TARGET_PATH)/, $(SONIC_BAZEL_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform \
+		$$(addprefix $(TARGET_PATH)/,$$($$*.gz_BAZEL_BASE))
+	$(HEADER)
+	bazel run --config=slave //dockers/$*:write_$*.gz $(LOG)
+	$(FOOTER)
+
+SONIC_TARGET_LIST += $(addprefix $(TARGET_PATH)/, $(SONIC_BAZEL_DOCKER_IMAGES))
+```
+
+Please note that these new targets depend on make-built base images, through the `$*_BAZEL_BASE` condition.
+We have written [some tooling to import make-built base images into Bazel](https://github.com/sonic-net/sonic-buildimage/tree/e09be005b19c3521c674e4415d08a25648fc15f4/tools/bazel/oci), but they are out of scope of this section.
+
+This ensures that Bazel-built dockers are built exactly any other Docker, in the slave container, while maintaining Bazel's benefits like hermeticity and a more granular cache.
+It also ensures that **there should be no change to the workflow of someone using Bazel**. The way they call make is the same, and the produced artifacts should be interchangeable.
+
+Our goal is that there can be ICs that have switched to Bazel without realizing it.
+
+#### 7.b Groundwork
 
 The Bazel ethos is that **every input to a build must be known, down to the checksum, before the build starts**. The current build system has a few instances where we cannot deterministically predict these inputs.
 
-- Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](https://github.com/thesayyn/sonic-build-infra/tree/master/toolchains/gcc).
-- Fetch Debian packages deterministically, instead of relying in `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](https://github.com/thesayyn/sonic-buildimage/blob/master/dockers/docker-base-bookworm/base_bookworm.MODULE.bazel).
-- For components that have Python dependencies, we created `pyproject.toml` files to be able to generate deterministic `uv` lockfiles. [Example](https://github.com/thesayyn/sonic-utilities/blob/master/pyproject.toml).
+- Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](https://github.com/blorente/sonic-build-infra/tree/master/toolchains/gcc).
+- Fetch Debian packages deterministically, instead of relying in `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](TODO LInk to the PR).
 
-#### 7.b Managing Patched External Dependencies
+#### 7.c Managing Patched External Dependencies
 
-The SONiC build relies on patching several third party dependencies (e.g. [libnl3](https://github.com/thesayyn/sonic-buildimage/tree/master/src/libnl3)). Furthermore, it relies on the Debian suite of tools ([debhelper](https://man7.org/linux/man-pages/man1/dh.1.html) and associated tools), which is not compatible with Bazel. Hence, another solution is required.
+The SONiC build relies on patching several third party dependencies (e.g. [libnl3](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/src/libnl3/BUILD.bazel)). Furthermore, it relies on the Debian suite of tools ([debhelper](https://man7.org/linux/man-pages/man1/dh.1.html) and associated tools), which is not compatible with Bazel. Hence, another solution is required.
 
-We propose four approaches to tackle this problem. They are detailed in [this PR to `thesayyn/sonic-buidimage`](https://github.com/thesayyn/sonic-buildimage/pull/15), but we will list their summaries here for ease of reference.
+We propose four approaches to tackle this problem. They are detailed in [this documentation](https://github.com/thesayyn/sonic-buildimage/blob/master/tools/bazel/docs/import-external-projects.md), but we will list their summaries here for ease of reference.
 
 In order of most preferred to least preferred, they are:
 
@@ -191,14 +260,16 @@ In order of most preferred to least preferred, they are:
 3. Migrate said dependency to Bazel. The specific method will depend on the dependency, but tips and tricks have been listed in the document above.
 4. Patch and build the dependency out of band, and then import the built artifacts into the Bazel build.
 
-#### 7.c Building Component Containers
+An early draft of documentation explaining these can be found [here](https://github.com/thesayyn/sonic-buildimage/blob/master/tools/bazel/docs/import-external-projects.md).
+
+#### 7.d Building Component Containers
 
 Currently, most components in SONiC are bundled into `.deb` archives before being installed in the containers to be deployed.
 
 We propose a similar model except, instead of `.deb` archives, we will bundle the components into tar archives for ease of consumption. Using `tar.bzl` and `mtree`, we can replicate the rootfs structure of `.deb` packages:
 
 ```starlark
-# Example from: https://github.com/thesayyn/sonic-buildimage/blob/master/src/sonic-sysmgr/BUILD.bazel#L4-L11
+# Example from: https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/src/sonic-sysmgr/BUILD.bazel#L4-L11
 # Note how we're able to place a file in `/debian/sysmgr/rebootbackend`.
 tar(
     name = "sysmgr_pkg",
@@ -213,31 +284,28 @@ tar(
 Then, we can skip the `apt install` step of building containers and just treat each tar as an OCI container layer with `rules_oci`:
 
 ```starlark
-# Example from: https://github.com/thesayyn/sonic-buildimage/blob/master/dockers/docker-base-bookworm/BUILD.bazel#L123-L139
+# Example from: https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/dockers/docker-sysmgr/BUILD.bazel#L59-L72
 oci_image(
-    name = "docker-base-bookworm",
-    architecture = "amd64",
-    entrypoint = ["/usr/bin/supervisord"],
+    name = "docker-sysmgr",
+    base = ":config_engine_base_layout",
+    entrypoint = ["/usr/local/bin/supervisord"],
     env = {
         "DEBIAN_FRONTEND": "noninteractive",
     },
-    os = "linux",
-    tars = [ # Each of these is a tar() target.
-        ":rootfs",
-        ":rootdirslinks",
-        ":flat",
-        ":site-packages",
-        "@sonic_supervisord_utilities//:dist",
+    tars = [
+        ":apt_deps",
+        ":rdeps",
+        ":source_files",
     ],
     visibility = ["//visibility:public"],
 )
 ```
 
-#### 7.d Platform & Device Support
+#### 7.e Platform & Device Support
 
 The current SONiC build supports a rich matrix of vendors, platforms, and devices. This can be replicated with Bazel's expressive configuration language.
 
-We define command line flags to allow users to specify which device and ASIC manufacturer they're targeting ([link](https://github.com/thesayyn/sonic-build-infra/blob/master/config/BUILD.bazel)):
+We define command line flags to allow users to specify which device and ASIC manufacturer they're targeting ([link](https://github.com/blorente/sonic-build-infra/blob/master/config/BUILD.bazel)):
 
 ```starlark
 # SONiC platform, which maps to ASIC manufacturers
@@ -287,13 +355,13 @@ For ease of use, we propose bundling default configurations for well-known combi
 $ bazel build <target> --config=broadcom # Equivalent to the above.
 ```
 
-#### 7.e Debuggability
+#### 7.f Debuggability
 
 We will implmement automatic debug container generation, mirroring the current system.
 
 We will write a Bazel rule that will crawl the dependency tree of an image, capture the debug symbols of its binaries, and bundle them with well-known debugging tools such as `gdb` to create debug containers.
 
-For instance, following the example in [7.d](#7d-platform--device-support):
+For instance, following the example in [7.e](#7e-platform--device-support):
 
 ```starlark
 oci_image(
@@ -309,7 +377,7 @@ debug_container(
 
 Users will then be able to load these containers into switches normally for debugging.
 
-#### 7.f Affected Systems
+#### 7.g Affected Systems
 
 ##### Dependency Changes
 
@@ -326,21 +394,11 @@ And we gain a few dependencies:
 
 Every component repository will need to be migrated to Bazel. `sonic-buildimage` will also need to change, but it will be migrated piecemeal.
 
-#### 7.g Performance Summary
+#### 7.h Performance Summary
 
 We expect the resulting containers to be comparable (if not equal) to those produced by the old build system, both in terms of size and runtime performance and memory footprint.
 
 We aim for build times to be reduced dramatically, especially for incremental builds. We expect noticeable second-order effects on developer ergonomics, as a more reliable build means fewer cold builds overall. We expect on-disk build caches to be significantly larger than those of the old build system.
-
-#### 7.h Bazel/make interoperability
-
-During the migration, Bazel and make will have to interoperate. We propose a model where we introduce top-level make targets for Bazel-compatible containers.
-
-// TODO BL: Fill out with code examples
-
-Some other considerations:
-- Bazel should consume layers built by make.
-- Bazel would execute inside the slave container for now. There are still hermeticity issues in the Bazel build, so it does end up depending on the host system. Therefore, to ensure interoperability with the make-built layers, we'll build in the slave container. These hermeticity issues should be treated as bugs, but in the interest of getting the build in the hands of users we choose to solve them later in the migration.
 
 ### 8. SAI API 
 

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -250,7 +250,7 @@ This section describes how individual components are built with Bazel, focusing 
 The Bazel ethos is that **every input to a build must be known, down to the checksum, before the build starts**. The current build system has a few instances where we cannot deterministically predict these inputs.
 
 - Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](https://github.com/blorente/sonic-build-infra/tree/master/toolchains/gcc).
-- Fetch Debian packages deterministically, instead of relying on `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](TODO LInk to the PR).
+- Fetch Debian packages deterministically, instead of relying on `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/MODULE.bazel#L23-L56).
 
 ##### 7.b.2 Managing Patched External Dependencies
 

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -89,8 +89,11 @@ For each component, we will introduce the Bazel build for its container, while r
 Users can control whether they want to build with Bazel or GNU make with a command line flag:
 
 ```
-$ make build // TODO BL: Current command
-$ BUILD_WITH_BAZEL_WHEN_AVAILABLE=true make build  // TODO BL: Current command
+$ make target/docker-sysmgr.gz
+# Builds make-based target as usual
+
+$ BUILD_WITH_BAZEL_WHEN_AVAILABLE=true make target/docker-sysmgr.gz
+# make runs Bazel to build the target
 ```
 
 This flag will start off by default. The implementation of this flag's semantics is defined in [section 7.h](#7h-bazelmake-interoperability).

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -1,6 +1,6 @@
-# SONiC Build System Migration #
+# SONiC Build System Migration
 
-## Table of Content 
+## Table of Content
 
 1. [Revision](#1-revision)
 2. [Scope](#2-scope)
@@ -38,15 +38,15 @@
     - [13.2. System Test cases](#132-system-test-cases)
 14. [Open/Action items - if any](#14-openaction-items---if-any)
 
-### 1. Revision  
+### 1. Revision
 
-### 2. Scope  
+### 2. Scope
 
 This document covers the migration of the SONiC build system into a modern, Bazel-based system. It proposes an end state of the build system, as well as a migration path to get us there.
 
 Please note that this design covers only the migration of individual components. Migrating the full image assembly process is out of the scope of this document.
 
-### 3. Definitions/Abbreviations 
+### 3. Definitions/Abbreviations
 
 - Bazel: A build system open-sourced by Google. It specializes in polyglot builds, and promises fast, reproducible builds through hermeticity. [Documentation](https://bazel.build/docs)
 - Bazel rules, also called rulesets: Extensions to Bazel to provide additional capabilities, usually to integrate Bazel with a new programming language. Usually named `rules_<lang>`. For instance, `rules_go` extends Bazel to be able to build and test Go sources. [Documentation](https://bazel-docs-staging.netlify.app/versions/master/skylark/rules.html)
@@ -69,7 +69,7 @@ Please see these publications about our work:
 - Talk from OCP EMEA Summit 2026: https://www.youtube.com/watch?v=uSKCNDWuXjc
 - Blog article about our work:  https://aspect.build/blog/bazel-for-sonic
 
-### 4. Overview 
+### 4. Overview
 
 > [!tip]
 > A full example of migrating a container can be found in [sonic-buildimage#28005](https://github.com/sonic-net/sonic-buildimage/pull/28005).
@@ -87,7 +87,7 @@ Early results demonstrate that we can produce cold builds similar to those in th
 
 Bazel migrations are expensive, and famously disruptive. To alleviate this issue as much as possible, we propose a gradual, non-mandatory rollout.
 
-We will extend the existing build system with a new target type that can build docker containers in Bazel.
+We will **extend the existing build system** with a new target type that can build docker containers in Bazel.
 The mechanics of this new target are discussed in [7.a](#7a-changes-to-existing-build-system-bazelmake-interoperability).
 
 Users can control whether they want to build with Bazel or GNU make with a command line flag:
@@ -104,43 +104,72 @@ This flag will start off disabled by default. The implementation of this flag's 
 
 To minimize disruption, we propose the following phases to the migration:
 
-##### Phase 1: Opt-in trial period
+##### Phase 1: Trial of Bazel Infrastructure
 
-Phase 1 will introduce Bazel as an optional build system for some components. For this phase, `BUILD_WITH_BAZEL_WHEN_AVAILABLE` will be turned off by default.
-We will start with small components such as `sflow`, `teamd`, and `database`, and continue onto progressively larger leaf components until we have sufficient coverage to be representative of the Bazel build.
-We expect this phase to last until the November release.
+Phase 1 will introduce Bazel as an optional build system for some components. The goal is to validate whether and how SONiC could most benefit from Bazel.
+
+For this phase, `BUILD_WITH_BAZEL_WHEN_AVAILABLE` will be turned off by default.
+We will start adding Bazel builds for leaf, small components such as `sysmgr`, `p4rt`, and the small watchdog binaries, and continue onto progressively larger leaf components until we have sufficient coverage to be representative of the benefits and challenges that Bazel poses.
+
+All components should still be buildable with the regular Make-based flow.
+
+When a component is built with Bazel, this will entail:
+
+- Eliminating system dependencies (e.g. from `apt` and `whl`), as well as other sonic-make injected deps. All dependencies will go through the hermetic Bazel build graph.
+- Removing `deb` packages as an intermediate format, instead relying on the Bazel dependency graph.
+- Removing `docker` as a dependency, instead building containers directly with Bazel.
+
+However, we will not attempt to:
+
+- Build a component with Bazel outside of the SONiC Make infra, or outside the slave container. The interface for users will still be `make target/dockers-*.gz`.
+- Build the base layers in Bazel. Bazel will consume Make-built base layers (e.g. `docker-base-bookworm`, `config-engine`).
+
+**We expect this phase to last until the November release.**
 
 The community can use this period to experiment with Bazel, adopt it into their own builds, and generally gather information on whether this is a net benefit.
 
-After the November release, the community will face a decision point: Should we adopt Bazel fully?
+After the November release, the community will face a decision point: Should Bazel be a first-class build system in SONiC?
+
+Specifically:
+
+- Should Bazel be allowed to be the _only option_ for certain components (like it is today for `p4rt`)?
+- Should Bazel be allowed to handle most of the dependency graph for these components? As a consequence, some SONiC dependencies will have to be converted to Bazel (e.g. `sonic-utilities`).
 
 If we decide to move forward, we will continue onto Phase 2.
 
-##### Phase 2: Opt-out migration period
+##### Phase 2: Migration Period
 
 At the start of this phase, we will flip `BUILD_WITH_BAZEL_WHEN_AVAILABLE` to be on by default.
 This will signal to the community that we do intend to adopt Bazel, and that they should start adopting it into their internal forks if they haven't already.
 
-We expect to massively increase coverage of targets that build with Bazel, specifically extending to building the base layers (`docker-base-*`, `docker-config-engine-*`, and `docker-swss-layer-*`) with Bazel by default.
+By turning `BUILD_WITH_BAZEL_WHEN_AVAILABLE` on, we'll also be making the Bazel build **blocking in CI**. As a consequence, any changes that break the Bazel build will have to be fixed before they're merged.
+
+It is possible that, at this point, the need arises for a per-target toggle. This is left as an [open question](#14-openaction-items---if-any).
+
+We expect to increase coverage of targets that build with Bazel. Specifically, we'll transition to building the base layers (`docker-base-*`, `docker-config-engine-*`, and `docker-swss-layer-*`) with Bazel by default.
 
 By the end of this phase, we expect most users to be able to build their components entirely in Bazel, without the need of a slave container.
 
+**This opt-out window will only exist for 1 release. After that, we will move into Phase 3.**
+
 ##### Phase 3: Bazel-only
 
-When every component can be built with Bazel, and most users have had a reasonable opportunity to migrate, we expect to be able to remove the current build system, and transition to using exclusively Bazel.
+When most users have had a reasonable opportunity to migrate (1 release after the Bazel build was introduced to a component), component owners will be able to **remove Make support** from their components entirely.
 
-We cannot give estimations of when this will be, as it will depend on community support and involvement.
+This can happen piecemeal, and be up to the discretion of each component owner.
 
 ##### CI considerations
 
 One open question is when we will establish a blocking CI pipeline for Bazel builds.
-We propose doing this early, as part of Phase 1.
 
-After the first container build merges, we will stand up a non-blocking CI pipeline that will test the Bazel build.
-That pipeline will run on every build, but failures in it won't block contributors from merging code.
+We propose the following structure:
 
-When that pipeline has been proven to be stable for a reasonable period, we propose to make it blocking, so that contributions that would break the Bazel build cannot be merged.
-This will avoid code drift between the two builds, helping tremendously with migration speed.
+- Phase 1: A nightly, post-merge job that tests the Bazel builds only. There are no expectations to keep this job green.
+- Phase 2: At the start of Phase 2, the components that are migrated to Bazell will now be blocking pre-merge, as we flip the default of `BUILD_WITH_BAZEL_WHEN_AVAILABLE`.
+
+This phased approach allows us to establish critical infrastructure and let the build mature before we make it required for anyone.
+
+We expect to be able to leverage the remote caching mechanism with Bazel to make these pipelines significantly faster than the Make-based version.
 
 ### 5. Requirements
 
@@ -166,11 +195,15 @@ The migration must satisfy the following requirements:
 6. Maintained developer experience
     * Automatic generation of debug containers, mirroring the current system
 
-### 6. Architecture Design 
+### 6. Architecture Design
 
-There are no expected changes to the SONiC architecture.
+There are no expected changes to the SONiC component architecture.
 
-### 7. High-Level Design 
+However, we will extende the SONiC build architecture to add a new target type for containers (read more in [Section 7.a](#7a-changes-to-existing-build-system-bazelmake-interoperability)).
+
+In addition, some of the existing dependency graph for libraries, binaries, and third party dependencies will move into Bazel.
+
+### 7. High-Level Design
 
 This section specifies how different parts of the build will work under Bazel.
 Everything explained here has already been implemented in a proof of concept migrating `docker-sysmgr`, in [sonic-buildimage#28005](https://github.com/sonic-net/sonic-buildimage/pull/28005).
@@ -251,6 +284,11 @@ The Bazel ethos is that **every input to a build must be known, down to the chec
 
 - Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](https://github.com/blorente/sonic-build-infra/tree/master/toolchains/gcc).
 - Fetch Debian packages deterministically, instead of relying on `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/MODULE.bazel#L23-L56).
+
+> [!warning]
+> During the transition, Bazel will consume base layers from the Make-based build. This can lead to discrepancies in runtime dependencies if we don't keep the `rules_distroless` dependencies up to date.
+>
+> This is not a regression, but it is one more synchronization point that we'll need to keep up to date temporarily.
 
 ##### 7.b.2 Managing Patched External Dependencies
 
@@ -415,17 +453,7 @@ There are no changes to the configuration.
 
 ### 10. Warmboot and Fastboot Design Impact  
 
-TODO BL: I probably need help from Brian for this
-
-### Warmboot and Fastboot Performance Impact
-This sub-section must cover the impact of the functionality on warmboot and fastboot performance, that is control plane and data plane downtime.
-As part of the analysis cover the following:
-
-- Does this feature add any stalls/sleeps/IO operations to the boot critical chain? Does it change when this feature is disabled/unused? 
-- Does this feature add any additional CPU heavy processing (e.g. rendering Jinja templates) in the boot path (process, library or utility used during boot up)? Does it change when this feature is disabled/unused?
-- In case this feature updates a third party dependency does it cause any impact on boot time performance?
-- Can the feature (service or docker) be delayed?
-- What are the possible optimizations and what is the expected boot time degradation if, by the nature of the feature, additional CPU/IO costs can't be avoided?
+This design doesn't impact warmboot
 
 ### 11. Memory Consumption
 
@@ -439,7 +467,9 @@ This means that, sometimes, we'll need to migrated dependencies to Bazel, which 
 
 ### 13. Testing Requirements/Design  
 
-// TODO BL: I probably need Brian's help for this, since his team has been donig the validation
+There are no new SONiC functional, unit, or system tests required.
+
+However, we will be adding CI jobs to validate the Bazel builds in the required environments, as outlined in the [CI Considerations](#ci-considerations). We expect to be able to leverage remote caching to make these builds significantly more performant than the alternative.
 
 #### 13.1. Unit Test cases  
 
@@ -447,4 +477,5 @@ This means that, sometimes, we'll need to migrated dependencies to Bazel, which 
 
 ### 14. Open/Action items - if any 
 
- // TODO BL:
+- **Should we add a per-component toggle during the migration?**
+  - If necessary, it's entirely possible to add a per-target flag, so that individual components can be toggled without affecting the rest of the build. We're not confident that the feature is needed, and the effort to implement it is relatively low, therefore we've left it out of this document.

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -2,6 +2,41 @@
 
 ## Table of Content 
 
+1. [Revision](#1-revision)
+2. [Scope](#2-scope)
+3. [Definitions/Abbreviations](#3-definitionsabbreviations)
+   - [3.a Prior Art](#3a-prior-art)
+4. [Overview](#4-overview)
+   - [4.a Motivation](#4a-motivation)
+   - [4.b Migration](#4b-migration)
+     - [Phase 1: Opt-in trial period](#phase-1-opt-in-trial-period)
+     - [Phase 2: Opt-out migration period](#phase-2-opt-out-migration-period)
+     - [Phase 3: Bazel-only](#phase-3-bazel-only)
+     - [CI considerations](#ci-considerations)
+5. [Requirements](#5-requirements)
+6. [Architecture Design](#6-architecture-design)
+7. [High-Level Design](#7-high-level-design)
+   - [7.a Groundwork](#7a-groundwork)
+   - [7.b Managing Patched External Dependencies](#7b-managing-patched-external-dependencies)
+   - [7.c Building Component Containers](#7c-building-component-containers)
+   - [7.d Platform & Device Support](#7d-platform--device-support)
+   - [7.e Debuggability](#7e-debuggability)
+   - [7.f Affected Systems](#7f-affected-systems)
+     - [Dependency Changes](#dependency-changes)
+     - [Changed Repositories](#changed-repositories)
+   - [7.g Performance Summary](#7g-performance-summary)
+   - [7.h Bazel/make interoperability](#7h-bazelmake-interoperability)
+8. [SAI API](#8-sai-api)
+9. [Configuration and management](#9-configuration-and-management)
+10. [Warmboot and Fastboot Design Impact](#10-warmboot-and-fastboot-design-impact)
+    - [Warmboot and Fastboot Performance Impact](#warmboot-and-fastboot-performance-impact)
+11. [Memory Consumption](#11-memory-consumption)
+12. [Restrictions/Limitations](#12-restrictionslimitations)
+13. [Testing Requirements/Design](#13-testing-requirementsdesign)
+    - [13.1. Unit Test cases](#131-unit-test-cases)
+    - [13.2. System Test cases](#132-system-test-cases)
+14. [Open/Action items - if any](#14-openaction-items---if-any)
+
 ### 1. Revision  
 
 ### 2. Scope  
@@ -14,7 +49,7 @@ Please note that this design covers only the migration of individual components.
 
 - Bazel: A build system open-sourced by Google. It specializes in polyglot builds, and promises fast, reproducible builds through hermeticity. [Documentation](https://bazel.build/docs)
 - Bazel rules, also called rulesets: Extensions to Bazel to provide additional capabilities, usually to integrate Bazel with a new programming language. Usually named `rules_<lang>`. For instance, `rules_go` extends Bazel to be able to build and test Go sources. [Documentation](https://bazel-docs-staging.netlify.app/versions/master/skylark/rules.html)
-- BUILD files: Files where the Bazel build is defined. Usually named `BUILD.bazel`, and written by hand in [Starlark](TODO BL: link to docs). [Documentation](https://bazel.build/concepts/build-files)
+- BUILD files: Files where the Bazel build is defined. Usually named `BUILD.bazel`, and written by hand in [Starlark](https://bazel.build/rules/language). [Documentation](https://bazel.build/concepts/build-files)
 - Bazel registry: A specially-shaped directory that hosts bazel rules and their versions. [Documentation](https://bazel.build/external/registry)
 - Bazel Central Registry, or BCR: The canonical, Google-maintained Bazel registry. Most rulesets live here, and most Bazel projects pull their rulesets from here. [Documentation](https://registry.bazel.build/)
 - bzlmod: Bazel's dependency resolution tool, which takes care of resolving ruleset dependencies. Automatically works with the BCR by default, but can be configured to resolve dependencies from other Bazel registries. [Documentation](https://bazel.build/external/overview)
@@ -58,7 +93,7 @@ $ make build // TODO BL: Current command
 $ BUILD_WITH_BAZEL_WHEN_AVAILABLE=true make build  // TODO BL: Current command
 ```
 
-This flag will start off by default. The implementation of this flag's semantics is defined in [TODO BL:](section 7.h).
+This flag will start off by default. The implementation of this flag's semantics is defined in [section 7.h](#7h-bazelmake-interoperability).
 
 To minimize disruption, we propose the following phases to the migration:
 
@@ -102,7 +137,27 @@ This will avoid code drift between the two builds, helping tremendously with mig
 
 ### 5. Requirements
 
-TODO BL: I need to read more what they expect here.
+The migration must satisfy the following requirements:
+
+1. Faster builds
+    * Cold builds comparable to those of the current system
+    * Sub-minute incremental builds for common classes of changes
+    * Aggressive caching, so that unchanged components are never rebuilt
+2. Hermetic and reproducible builds
+    * No dependency on the host system (e.g. host-installed `gcc`, `python`, or `docker`)
+    * The same build on the same commit produces the same artifacts
+3. Equivalent build output
+    * Resulting containers are comparable to those of the current system in size, runtime performance, and memory footprint
+    * No regression in functionality of the produced images
+4. Gradual migration
+    * Bazel and GNU make coexist, with per-component opt-in and opt-out controlled by a single flag
+    * Components are migrated one at a time, starting from the least depended-on
+    * A CI pipeline that validates the Bazel build to prevent drift between the two systems
+5. Platform and device coverage
+    * Present patterns to migrate the existing matrix of vendors, platforms, devices, and ASIC manufacturers
+    * Allow users to select the target platform and SAI implementation at build time from the command line
+6. Maintained developer experience
+    * Automatic generation of debug containers, mirroring the current system
 
 ### 6. Architecture Design 
 
@@ -116,13 +171,13 @@ This section specifies how different parts of the build will work under Bazel. E
 
 The Bazel ethos is that **every input to a build must be known, down to the checksum, before the build starts**. The current build system has a few instances where we cannot deterministically predict these inputs.
 
-- Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](TODO LINK to sonic-build-infra/toolchain).
-- Fetch Debian packages deterministically, instead of relying in `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](TODO BL: Source to code in sonic-buildimage that pulls this stuff).
-- For components that have Python dependencies, we created `pyproject.toml` files to be able to generate deterministic `uv` lockfiles. [Example](TODO BL: Example for sonic-utilities).
+- Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](https://github.com/thesayyn/sonic-build-infra/tree/master/toolchains/gcc).
+- Fetch Debian packages deterministically, instead of relying in `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](https://github.com/thesayyn/sonic-buildimage/blob/master/dockers/docker-base-bookworm/base_bookworm.MODULE.bazel).
+- For components that have Python dependencies, we created `pyproject.toml` files to be able to generate deterministic `uv` lockfiles. [Example](https://github.com/thesayyn/sonic-utilities/blob/master/pyproject.toml).
 
 #### 7.b Managing Patched External Dependencies
 
-The SONiC build relies on patching several third party dependencies (e.g. [libnl3](TODO BL: link to buildimage/src/libnl3)). Furthermore, it relies on the Debian suite of tools ([debhelper](https://man7.org/linux/man-pages/man1/dh.1.html) and associated tools), which is not compatible with Bazel. Hence, another solution is required.
+The SONiC build relies on patching several third party dependencies (e.g. [libnl3](https://github.com/thesayyn/sonic-buildimage/tree/master/src/libnl3)). Furthermore, it relies on the Debian suite of tools ([debhelper](https://man7.org/linux/man-pages/man1/dh.1.html) and associated tools), which is not compatible with Bazel. Hence, another solution is required.
 
 We propose four approaches to tackle this problem. They are detailed in [this PR to `thesayyn/sonic-buidimage`](https://github.com/thesayyn/sonic-buildimage/pull/15), but we will list their summaries here for ease of reference.
 
@@ -235,7 +290,7 @@ We will implmement automatic debug container generation, mirroring the current s
 
 We will write a Bazel rule that will crawl the dependency tree of an image, capture the debug symbols of its binaries, and bundle them with well-known debugging tools such as `gdb` to create debug containers.
 
-For instance, following the example in [7.d](TODO BL: LINK):
+For instance, following the example in [7.d](#7d-platform--device-support):
 
 ```starlark
 oci_image(

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -73,7 +73,7 @@ Please see these publications about our work:
 
 > [!tip]
 > A full example of migrating a container can be found in [sonic-buildimage#28005](https://github.com/sonic-net/sonic-buildimage/pull/28005).
-> We will explore the different moving pieces in that PR in [Section 7](7-high-level-design).
+> We will explore the different moving pieces in that PR in [Section 7](#7-high-level-design).
 
 #### 4.a Motivation
 
@@ -96,11 +96,11 @@ Users can control whether they want to build with Bazel or GNU make with a comma
 $ make target/docker-sysmgr.gz
 # Builds make-based target as usual
 
-$ BUILD_WITH_BAZEL_WHEN_AVAILABLE=true make target/docker-sysmgr.gz
+$ BUILD_WITH_BAZEL_WHEN_AVAILABLE=y make target/docker-sysmgr.gz
 # make runs Bazel to build the target
 ```
 
-This flag will start off by default. The implementation of this flag's semantics is defined in [section 7.a](#7a-changes-to-existing-build-system-bazelmake-interoperability).
+This flag will start off disabled by default. The implementation of this flag's semantics is defined in [section 7.a](#7a-changes-to-existing-build-system-bazelmake-interoperability).
 
 To minimize disruption, we propose the following phases to the migration:
 
@@ -127,7 +127,7 @@ By the end of this phase, we expect most users to be able to build their compone
 
 ##### Phase 3: Bazel-only
 
-When every component can be built with Bazel, and most users have had a reasonable opportunity to migratie, we expect to be able to remove the current build system, and transition to using exclusively Bazel.
+When every component can be built with Bazel, and most users have had a reasonable opportunity to migrate, we expect to be able to remove the current build system, and transition to using exclusively Bazel.
 
 We cannot give estimations of when this will be, as it will depend on community support and involvement.
 
@@ -236,21 +236,21 @@ SONIC_TARGET_LIST += $(addprefix $(TARGET_PATH)/, $(SONIC_BAZEL_DOCKER_IMAGES))
 Please note that these new targets depend on make-built base images, through the `$*_BAZEL_BASE` condition.
 We have written [some tooling to import make-built base images into Bazel](https://github.com/sonic-net/sonic-buildimage/tree/e09be005b19c3521c674e4415d08a25648fc15f4/tools/bazel/oci), but they are out of scope of this section.
 
-This ensures that Bazel-built dockers are built exactly any other Docker, in the slave container, while maintaining Bazel's benefits like hermeticity and a more granular cache.
+This ensures that Bazel-built dockers are built exactly like any other Docker, in the slave container, while maintaining Bazel's benefits like hermeticity and a more granular cache.
 It also ensures that **there should be no change to the workflow of someone using Bazel**. The way they call make is the same, and the produced artifacts should be interchangeable.
 
-Our goal is that there can be ICs that have switched to Bazel without realizing it.
+Our goal is that a contributor could switch to Bazel without even realizing it.
 
 #### 7.b Bazel Build
 
-This section describes how individual components are built with Bazel. It only touches on Bazel, not on any existing system.
+This section describes how individual components are built with Bazel, focusing on the Bazel build itself rather than its interoperability with the existing make-based system.
 
 ##### 7.b.1 Groundwork
 
 The Bazel ethos is that **every input to a build must be known, down to the checksum, before the build starts**. The current build system has a few instances where we cannot deterministically predict these inputs.
 
 - Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](https://github.com/blorente/sonic-build-infra/tree/master/toolchains/gcc).
-- Fetch Debian packages deterministically, instead of relying in `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](TODO LInk to the PR).
+- Fetch Debian packages deterministically, instead of relying on `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](TODO LInk to the PR).
 
 ##### 7.b.2 Managing Patched External Dependencies
 
@@ -362,7 +362,7 @@ $ bazel build <target> --config=broadcom # Equivalent to the above.
 
 ##### 7.b.5 Debuggability
 
-We will implmement automatic debug container generation, mirroring the current system.
+We will implement automatic debug container generation, mirroring the current system.
 
 We will write a Bazel rule that will crawl the dependency tree of an image, capture the debug symbols of its binaries, and bundle them with well-known debugging tools such as `gdb` to create debug containers.
 
@@ -386,8 +386,8 @@ Users will then be able to load these containers into switches normally for debu
 
 ###### Dependency Changes
 
-We lose a few dependencies:
-- We no longer need a sonic-slave container.
+Once components build entirely in Bazel, we lose a few dependencies:
+- We no longer need a sonic-slave container. Note that, during the migration, Bazel still runs inside the slave container (see [7.a](#7a-changes-to-existing-build-system-bazelmake-interoperability)); this dependency only goes away once a component builds entirely in Bazel.
 - We no longer depend on developer tools such as `gcc` and `python` being installed in the build machine.
 - We no longer depend on Docker at build time.
 
@@ -419,7 +419,7 @@ TODO BL: I probably need help from Brian for this
 
 ### Warmboot and Fastboot Performance Impact
 This sub-section must cover the impact of the functionality on warmboot and fastboot performance, that is control plane and data plane downtime.
-As part of the analysis cover the flowing:
+As part of the analysis cover the following:
 
 - Does this feature add any stalls/sleeps/IO operations to the boot critical chain? Does it change when this feature is disabled/unused? 
 - Does this feature add any additional CPU heavy processing (e.g. rendering Jinja templates) in the boot path (process, library or utility used during boot up)? Does it change when this feature is disabled/unused?

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -23,10 +23,10 @@
      - [7.b.3 Building Component Containers](#7b3-building-component-containers)
      - [7.b.4 Platform & Device Support](#7b4-platform--device-support)
      - [7.b.5 Debuggability](#7b5-debuggability)
-     - [7.b.6 Affected Systems](#7b6-affected-systems)
-       - [Dependency Changes](#dependency-changes)
-       - [Changed Repositories](#changed-repositories)
-     - [7.b.7 Performance Summary](#7b7-performance-summary)
+   - [7.c Affected Systems](#7c-affected-systems)
+     - [Dependency Changes](#dependency-changes)
+     - [Changed Repositories](#changed-repositories)
+   - [7.d Performance Summary](#7d-performance-summary)
 8. [SAI API](#8-sai-api)
 9. [Configuration and management](#9-configuration-and-management)
 10. [Warmboot and Fastboot Design Impact](#10-warmboot-and-fastboot-design-impact)
@@ -382,9 +382,9 @@ debug_container(
 
 Users will then be able to load these containers into switches normally for debugging.
 
-##### 7.b.6 Affected Systems
+#### 7.c Affected Systems
 
-###### Dependency Changes
+##### Dependency Changes
 
 Once components build entirely in Bazel, we lose a few dependencies:
 - We no longer need a sonic-slave container. Note that, during the migration, Bazel still runs inside the slave container (see [7.a](#7a-changes-to-existing-build-system-bazelmake-interoperability)); this dependency only goes away once a component builds entirely in Bazel.
@@ -395,11 +395,11 @@ And we gain a few dependencies:
 - We depend on Google servers to download and install Bazel at build time.
 - We gain a dependency on the Bazel Central Registry.
 
-###### Changed Repositories
+##### Changed Repositories
 
 Every component repository will need to be migrated to Bazel. `sonic-buildimage` will also need to change, but it will be migrated piecemeal.
 
-##### 7.b.7 Performance Summary
+#### 7.d Performance Summary
 
 We expect the resulting containers to be comparable (if not equal) to those produced by the old build system, both in terms of size and runtime performance and memory footprint.
 

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -16,16 +16,17 @@
 5. [Requirements](#5-requirements)
 6. [Architecture Design](#6-architecture-design)
 7. [High-Level Design](#7-high-level-design)
-   - [7.a Bazel/make interoperability](#7a-bazelmake-interoperability)
-   - [7.b Groundwork](#7b-groundwork)
-   - [7.c Managing Patched External Dependencies](#7c-managing-patched-external-dependencies)
-   - [7.d Building Component Containers](#7d-building-component-containers)
-   - [7.e Platform & Device Support](#7e-platform--device-support)
-   - [7.f Debuggability](#7f-debuggability)
-   - [7.g Affected Systems](#7g-affected-systems)
-     - [Dependency Changes](#dependency-changes)
-     - [Changed Repositories](#changed-repositories)
-   - [7.h Performance Summary](#7h-performance-summary)
+   - [7.a Changes to Existing Build System (Bazel/make Interoperability)](#7a-changes-to-existing-build-system-bazelmake-interoperability)
+   - [7.b Bazel Build](#7b-bazel-build)
+     - [7.b.1 Groundwork](#7b1-groundwork)
+     - [7.b.2 Managing Patched External Dependencies](#7b2-managing-patched-external-dependencies)
+     - [7.b.3 Building Component Containers](#7b3-building-component-containers)
+     - [7.b.4 Platform & Device Support](#7b4-platform--device-support)
+     - [7.b.5 Debuggability](#7b5-debuggability)
+     - [7.b.6 Affected Systems](#7b6-affected-systems)
+       - [Dependency Changes](#dependency-changes)
+       - [Changed Repositories](#changed-repositories)
+     - [7.b.7 Performance Summary](#7b7-performance-summary)
 8. [SAI API](#8-sai-api)
 9. [Configuration and management](#9-configuration-and-management)
 10. [Warmboot and Fastboot Design Impact](#10-warmboot-and-fastboot-design-impact)
@@ -87,7 +88,7 @@ Early results demonstrate that we can produce cold builds similar to those in th
 Bazel migrations are expensive, and famously disruptive. To alleviate this issue as much as possible, we propose a gradual, non-mandatory rollout.
 
 We will extend the existing build system with a new target type that can build docker containers in Bazel.
-The mechanics of this new target are discussed in [7.a](#7a-bazelmake-interoperability).
+The mechanics of this new target are discussed in [7.a](#7a-changes-to-existing-build-system-bazelmake-interoperability).
 
 Users can control whether they want to build with Bazel or GNU make with a command line flag:
 
@@ -99,7 +100,7 @@ $ BUILD_WITH_BAZEL_WHEN_AVAILABLE=true make target/docker-sysmgr.gz
 # make runs Bazel to build the target
 ```
 
-This flag will start off by default. The implementation of this flag's semantics is defined in [section 7.a](#7a-bazelmake-interoperability).
+This flag will start off by default. The implementation of this flag's semantics is defined in [section 7.a](#7a-changes-to-existing-build-system-bazelmake-interoperability).
 
 To minimize disruption, we propose the following phases to the migration:
 
@@ -240,14 +241,18 @@ It also ensures that **there should be no change to the workflow of someone usin
 
 Our goal is that there can be ICs that have switched to Bazel without realizing it.
 
-#### 7.b Groundwork
+#### 7.b Bazel Build
+
+This section describes how individual components are built with Bazel. It only touches on Bazel, not on any existing system.
+
+##### 7.b.1 Groundwork
 
 The Bazel ethos is that **every input to a build must be known, down to the checksum, before the build starts**. The current build system has a few instances where we cannot deterministically predict these inputs.
 
 - Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](https://github.com/blorente/sonic-build-infra/tree/master/toolchains/gcc).
 - Fetch Debian packages deterministically, instead of relying in `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](TODO LInk to the PR).
 
-#### 7.c Managing Patched External Dependencies
+##### 7.b.2 Managing Patched External Dependencies
 
 The SONiC build relies on patching several third party dependencies (e.g. [libnl3](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/src/libnl3/BUILD.bazel)). Furthermore, it relies on the Debian suite of tools ([debhelper](https://man7.org/linux/man-pages/man1/dh.1.html) and associated tools), which is not compatible with Bazel. Hence, another solution is required.
 
@@ -262,7 +267,7 @@ In order of most preferred to least preferred, they are:
 
 An early draft of documentation explaining these can be found [here](https://github.com/thesayyn/sonic-buildimage/blob/master/tools/bazel/docs/import-external-projects.md).
 
-#### 7.d Building Component Containers
+##### 7.b.3 Building Component Containers
 
 Currently, most components in SONiC are bundled into `.deb` archives before being installed in the containers to be deployed.
 
@@ -301,7 +306,7 @@ oci_image(
 )
 ```
 
-#### 7.e Platform & Device Support
+##### 7.b.4 Platform & Device Support
 
 The current SONiC build supports a rich matrix of vendors, platforms, and devices. This can be replicated with Bazel's expressive configuration language.
 
@@ -355,13 +360,13 @@ For ease of use, we propose bundling default configurations for well-known combi
 $ bazel build <target> --config=broadcom # Equivalent to the above.
 ```
 
-#### 7.f Debuggability
+##### 7.b.5 Debuggability
 
 We will implmement automatic debug container generation, mirroring the current system.
 
 We will write a Bazel rule that will crawl the dependency tree of an image, capture the debug symbols of its binaries, and bundle them with well-known debugging tools such as `gdb` to create debug containers.
 
-For instance, following the example in [7.e](#7e-platform--device-support):
+For instance, following the example in [7.b.4](#7b4-platform--device-support):
 
 ```starlark
 oci_image(
@@ -377,9 +382,9 @@ debug_container(
 
 Users will then be able to load these containers into switches normally for debugging.
 
-#### 7.g Affected Systems
+##### 7.b.6 Affected Systems
 
-##### Dependency Changes
+###### Dependency Changes
 
 We lose a few dependencies:
 - We no longer need a sonic-slave container.
@@ -390,11 +395,11 @@ And we gain a few dependencies:
 - We depend on Google servers to download and install Bazel at build time.
 - We gain a dependency on the Bazel Central Registry.
 
-##### Changed Repositories
+###### Changed Repositories
 
 Every component repository will need to be migrated to Bazel. `sonic-buildimage` will also need to change, but it will be migrated piecemeal.
 
-#### 7.h Performance Summary
+##### 7.b.7 Performance Summary
 
 We expect the resulting containers to be comparable (if not equal) to those produced by the old build system, both in terms of size and runtime performance and memory footprint.
 

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -1,6 +1,6 @@
 # SONiC Build System Migration
 
-## Table of Content
+## Table of Contents
 
 1. [Revision](#1-revision)
 2. [Scope](#2-scope)
@@ -9,8 +9,8 @@
 4. [Overview](#4-overview)
    - [4.a Motivation](#4a-motivation)
    - [4.b Migration](#4b-migration)
-     - [Phase 1: Opt-in trial period](#phase-1-opt-in-trial-period)
-     - [Phase 2: Opt-out migration period](#phase-2-opt-out-migration-period)
+     - [Phase 1: Trial of Bazel Infrastructure](#phase-1-trial-of-bazel-infrastructure)
+     - [Phase 2: Migration Period](#phase-2-migration-period)
      - [Phase 3: Bazel-only](#phase-3-bazel-only)
      - [CI considerations](#ci-considerations)
 5. [Requirements](#5-requirements)
@@ -50,14 +50,14 @@ Core Definitions
 - Component: When we reference "SONiC components" here, we're generally talking about "a unit of work that can exist and be built in isolation".
     - For this document, it is useful to think of components as "pieces of functionality that would make sense to migrate at once".
     - A useful heuristic to figure out what is and isn't a component is to look at `<sonic-buildimage>/rules/*.mk`. If it has an `*.mk` file, we'll likely call it a component.
-    - First party `.deb` files, first party wheels (e.g. `sonic-utilities`), and containers are components. The tests for `sonic-swss` are _not_ a component.
+    - First-party `.deb` files, first-party wheels (e.g. `sonic-utilities`), and containers are components. The tests for `sonic-swss` are _not_ a component.
 
 Bazel Definitions
 
 - Bazel: A build system open-sourced by Google. It specializes in polyglot builds, and promises fast, reproducible builds through hermeticity. [Documentation](https://bazel.build/docs)
 - Bazel target: The unit of a build. A target represents one or more inputs and produces one or more outputs. For instance, "the docker image for syncd" is a target, but so is "the shared library of sonic_swss_common". [Documentation](https://bazel.build/concepts/build-ref)
 - Label: The unique identifier of a target. It follows the syntax `@<repository name>//path/to/target:<target name>` . For instance, `@sonic_buildimage//dockers/docker-base-bookworm:docker-base-bookworm` refers to [this target](https://github.com/thesayyn/sonic-buildimage/blob/04f2d3bf54650b1ceecb663a11f53be6810856f1/dockers/docker-base-bookworm/BUILD.bazel#L123-L139). [Documentation](https://bazel.build/concepts/labels)
-- Bazel rules, also called rulesets: Extensions to Bazel to provide additional capabilities, usually to integrate Bazel with a new programming language. Usually named `rules_<lang>`. For instance, `rules_go` extends Bazel to be able to build and test Go sources. Over time, more of the basic Bazel capabilities have migrated into rules (e.g. `rules_java`) [Documentation](https://bazel-docs-staging.netlify.app/versions/master/skylark/rules.html)
+- Bazel rules, also called rulesets: Extensions to Bazel to provide additional capabilities, usually to integrate Bazel with a new programming language. Usually named `rules_<lang>`. For instance, `rules_go` extends Bazel to be able to build and test Go sources. Over time, more of the basic Bazel capabilities have migrated into rules (e.g. `rules_java`). [Documentation](https://bazel-docs-staging.netlify.app/versions/master/skylark/rules.html)
 - BUILD files: Files where the Bazel build is defined. Usually named `BUILD.bazel`, and written by hand in [Starlark](https://bazel.build/rules/language). [Documentation](https://bazel.build/concepts/build-files)
 - Bazel registry: A specially-shaped directory that hosts bazel rules and their versions. [Documentation](https://bazel.build/external/registry)
     - A registry can be hosted either in the local filesystem, or in an HTTP server (e.g. a GitHub repository).
@@ -76,7 +76,7 @@ We have already implemented large parts of this document as proofs of concept.
 
 Please see these publications about our work:
 - Talk from OCP EMEA Summit 2026: https://www.youtube.com/watch?v=uSKCNDWuXjc
-- Blog article about our work:  https://aspect.build/blog/bazel-for-sonic
+- Blog article about our work: https://aspect.build/blog/bazel-for-sonic
 
 ### 4. Overview
 
@@ -86,9 +86,9 @@ Please see these publications about our work:
 
 #### 4.a Motivation
 
-The current SONiC build system, while being ergonomic and accommodating the vast matrix of platforms and vendors that are required, has some shortcomings, that the community has been feeling for some time.
+The current SONiC build system, while being ergonomic and accommodating the vast matrix of platforms and vendors that are required, has some shortcomings that the community has been feeling for some time.
 
-After two decades of SONiC development, we now have a fuller picture of what SONiC needs in a build. With this information, we believe we can build a faster, more reliable build system on top of Bazel.
+After a decade of SONiC development, we now have a fuller picture of what SONiC needs in a build. With this information, we believe we can build a faster, more reliable build system on top of Bazel.
 
 Early results demonstrate that we can produce cold builds similar to those in the current system, but **sub-minute builds** for some classes of incremental changes, all while keeping hermeticity and reproducibility, so that the same build on the same commit will produce the same results a year from now.
 
@@ -123,16 +123,18 @@ We will aim to migrate entire containers at once, though it's possible that a co
 We will start adding Bazel builds for leaf, small containers such as `sysmgr`, `p4rt`, and the small watchdog binaries, and continue onto progressively larger leaf containers until we have sufficient coverage to be representative of the benefits and challenges that Bazel poses.
 
 All components (containers and individual `.deb`s) should still be buildable with the regular Make-based flow.
+We accept that this will cause behavior drift between the Bazel and Make build systems.
+However, in our early experimentation, this drift was both easy to catch and quick to fix.
 
 When a container is built with Bazel, this will entail:
 
-- Eliminating system dependencies for that container (e.g. from `apt` and `whl`), as well as other sonic-make injected deps. All dependencies will go through the hermetic Bazel build graph.
-- Removing `deb` packages as an intermediate format for that container, instead relying on the Bazel dependency graph. We will retain the ability to create `deb` packages with Bazel, it will just not be required.
+- Eliminating system dependencies for that container (e.g. from `apt` and `whl`), as well as other sonic-make-injected deps. All dependencies will go through the hermetic Bazel build graph.
+- Removing `deb` packages as an intermediate format for that container, instead relying on the Bazel dependency graph. For instance: In the current build system, we build `sysmgr_1.0.0_amd64.deb` just to install it in a container. In Bazel, we will retain the ability to create `sysmgr_1.0.0_amd64.deb`, but we will install the raw tar file into the image.
 - Removing `docker` as a dependency for that container, instead building containers directly with Bazel.
 
 However, we will not attempt to:
 
-- Build a container with Bazel outside of the SONiC Make infra, or outside the slave container. The interface for users will still be `make target/dockers-*.gz`.
+- Build a container with Bazel outside of the SONiC Make infra, or outside the slave container. The interface for users will still be `make target/docker-*.gz`.
 - Build the base layers in Bazel. Bazel will consume Make-built base layers (e.g. `docker-base-trixie`, `config-engine`).
 
 The community can use this period to experiment with Bazel, adopt it into their own builds, and generally gather information on whether this is a net benefit.
@@ -148,7 +150,7 @@ Specifically:
 - Is the development experience in Bazel supported well enough to be used in day-to-day operations for migrated components and containers?
     - Are there any gaps left to fill before this is true?
 - Should Bazel be allowed to be the _only option_ for certain containers (like it is today for `p4rt`)?
-- Should Bazel be allowed to handle most of the dependency graph for these containers? As a consequence, some SONiC dependencies will have to be converted to Bazel (e.g. `sonic-utilities`).
+- Should Bazel be allowed to handle the dependency graph for these containers? As a consequence, some SONiC dependencies will have to be converted to Bazel (e.g. `sonic-utilities`).
 
 If we decide there are still gaps, we will work to correct them before proceeding.
 
@@ -159,19 +161,19 @@ If we decide to move forward, we will continue onto Phase 2.
 At the start of this phase, we will flip `BUILD_WITH_BAZEL_WHEN_AVAILABLE` to be on by default.
 This will signal to the community that we do intend to adopt Bazel, and that they should start adopting it into their internal forks if they haven't already.
 
-By turning `BUILD_WITH_BAZEL_WHEN_AVAILABLE` on, we'll also be making the Bazel build **blocking in CI**. As a consequence, any changes that break the Bazel build will have to be fixed before they're merged.
+This will require an up-front effort to reconcile regressions that may have happened between the start and end of Phase 1.
+However, by turning `BUILD_WITH_BAZEL_WHEN_AVAILABLE` on, we'll also be making the Bazel build **blocking in CI**. As a consequence, any changes that break the Bazel build will have to be fixed before they're merged.
 
 It is possible that, at this point, the need arises for a per-component Bazel toggle. This is left as an [open question](#14-openaction-items---if-any).
 
 We expect to increase coverage of targets that build with Bazel. Specifically, we'll transition to building the base layers (`docker-base-*`, `docker-config-engine-*`, and `docker-swss-layer-*`) with Bazel by default.
+As a consequence, by the end of this phase, we expect most users to be able to build their components entirely in Bazel, without the need of a slave container.
 
-By the end of this phase, we expect most users to be able to build their components entirely in Bazel, without the need of a slave container.
-
-**This opt-out window will only exist for 1 release after the Bazel build for a component has been introduced. After that, we will move into Phase 3.**
+**This opt-out window will only exist for a pre-agreed grace period after the Bazel build for a component has been introduced. We strongly suggest 1 release, but it could be made longer for more complex components. After that, we will move into Phase 3.**
 
 ##### Phase 3: Bazel-only
 
-When most users have had a reasonable opportunity to migrate (1 release after the Bazel build was introduced to a component), component owners will be able to **remove Make support** from their components entirely.
+When most users have had a reasonable opportunity to migrate, component owners will be able to **remove Make support** from their components entirely.
 
 This can happen piecemeal, and be up to the discretion of each component owner.
 
@@ -181,12 +183,12 @@ One open question is when we will establish a blocking CI pipeline for Bazel bui
 
 We propose the following structure:
 
-- Phase 1: A nightly, post-merge job that tests the Bazel builds only. There are no expectations to keep this job green, but it will be useful in spotting regressions.
-- Phase 2: Bazel builds are blocking pre-submit. When we flip the default of `BUILD_WITH_BAZEL_WHEN_AVAILABLE`, the components that are migrated to Bazel will now be blocking the pre-submit checks.
+- At the beginning of Phase 1: A nightly, post-merge job that tests the Bazel builds only. There are no expectations to keep this job green, but it will be useful in spotting regressions.
+- At the beginning of Phase 2: Bazel builds are blocking pre-submit. When we flip the default of `BUILD_WITH_BAZEL_WHEN_AVAILABLE`, the components that are migrated to Bazel will now be blocking the pre-submit checks.
 
 This phased approach allows us to establish critical infrastructure and let the build mature before we make it required for anyone.
 
-We expect to be able to leverage the remote caching mechanism with Bazel to make these pipelines significantly faster than the Make-based version.
+We expect to be able to leverage the remote caching mechanism with Bazel to make these pipelines significantly faster than the Make-based version. The hosting and trust model of the cache are Open Questions, though we note that there is significant prior art that makes us confident that it can be done.
 
 ### 5. Requirements
 
@@ -207,7 +209,7 @@ The migration must satisfy the following requirements:
     * Components are migrated one at a time, starting from the least depended-on
     * A CI pipeline that validates the Bazel build to prevent drift between the two systems
 5. Platform and device coverage
-    * Present patterns to migrate the existing matrix of vendors, platforms, devices, and ASIC manufacturers
+    * Present patterns to migrate the existing matrix of CPU architectures, vendors, platforms, devices, and ASIC manufacturers
     * Allow users to select the target platform and SAI implementation at build time from the command line
 6. Maintained developer experience
     * Automatic generation of debug containers, mirroring the current system
@@ -257,7 +259,7 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_SYSMGR)
 ...
 ```
 
-As shown in the example, the `BUILD_WITH_BAZEL_WHEN_AVAILABLE` configuration flag will toggle the entire Bazel behaviour. When switched off, the system will use the regular make-based build:
+As shown in the example, the `BUILD_WITH_BAZEL_WHEN_AVAILABLE` configuration flag will toggle the entire Bazel behavior. When switched off, the system will use the regular make-based build:
 
 ```make
 # From sonic-buildimage#28005/rules/config
@@ -287,13 +289,14 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_BAZEL_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz
 SONIC_TARGET_LIST += $(addprefix $(TARGET_PATH)/, $(SONIC_BAZEL_DOCKER_IMAGES))
 ```
 
-Please note that these new targets depend on make-built base images, through the `$*_BAZEL_BASE` condition.
-We have written [some tooling to import make-built base images into Bazel](https://github.com/sonic-net/sonic-buildimage/tree/e09be005b19c3521c674e4415d08a25648fc15f4/tools/bazel/oci), but they are out of scope of this section.
+Please note that these new targets depend on make-built base images, through the `$*_BAZEL_BASE` variable.
+We have written [some tooling to import make-built base images into Bazel](https://github.com/sonic-net/sonic-buildimage/tree/e09be005b19c3521c674e4415d08a25648fc15f4/tools/bazel/oci), but it is out of scope of this section.
 
 This ensures that Bazel-built dockers are built exactly like any other Docker, in the slave container, while maintaining Bazel's benefits like hermeticity and a more granular cache.
-It also ensures that **there should be no change to the workflow of someone using Bazel**. The way they call make is the same, and the produced artifacts should be interchangeable.
+It also ensures that **there should be no change to the workflow of someone using Bazel**. The way they call make is the same, and the produced artifacts should be analogous to each other.
+They will not be byte-by-byte identical, because the Make-based system produces Docker images, whereas Bazel will produce OCI images. The SONiC container runtime can load both.
 
-Our goal is that a contributor could switch to Bazel without even realizing it.
+Our goal is that a contributor could switch to Bazel without even realizing it (save a performance delay when downloading dependencies for the first time).
 
 #### 7.b Bazel Build
 
@@ -303,13 +306,17 @@ This section describes how individual components are built with Bazel, focusing 
 
 The Bazel ethos is that **every input to a build must be known, down to the checksum, before the build starts**. The current build system has a few instances where we cannot deterministically predict these inputs.
 
-- Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](https://github.com/blorente/sonic-build-infra/tree/master/toolchains/gcc).
+As part of preparing the repository for the migration, we have done the following groundwork:
+
+- Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](https://github.com/blorente/sonic-build-infra/tree/master/toolchains/gcc). The toolchain will be chosen to be compatible with the apt packages downloaded for that Debian version. The one in the source, for instance, is ABI-compatible with Bookworm. This version can be changed as we discover more facts. For instance, if we discover that we need a more specific gcc to maintain ABI compatibility for a particular vendor's SAI implementation, we can generate new toolchains at will through [blorente/gcc-builds](https://github.com/blorente/gcc-builds).
 - Fetch Debian packages deterministically, instead of relying on `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/MODULE.bazel#L23-L56). Please note that this only refers to the Bazel ruleset, and is **unrelated to distroless containers** as a concept. Switching to distroless containers is out of the scope of this document.
 
 > [!warning]
 > During the transition, Bazel will consume base layers from the Make-based build. This can lead to discrepancies in runtime dependencies if we don't keep the `rules_distroless` dependencies up to date.
 >
 > This is not a regression, but it is one more synchronization point that we'll need to keep up to date temporarily.
+
+Please note that this groundwork alone is not sufficient to guarantee full reproducibility. For instance, we'll still rely on `snapshot.debian.org` being available. However, this brings us close enough that we can start working on the Bazel build.
 
 ##### 7.b.2 Managing Patched External Dependencies
 
@@ -319,10 +326,10 @@ We propose four approaches to tackle this problem. They are detailed in [this do
 
 In order of most preferred to least preferred, they are:
 
-1. Find the module we want to patch in the BCR. Please see the PR for instructions on how to patch it.
+1. Find the module we want to patch in the BCR. Please see the PR for instructions on how to patch it. Note that we would be taking on a dependency on the BCR, which is backed by a public GitHub repository. There are mitigations for this (e.g. a shared, community mirroring service such as Artifactory), which we will discuss in the working group.
 2. Pull the dependency as a Debian package with `rules_distroless`. This method does not build the dependencies from source, and thus **does not allow patching**.
-3. Migrate said dependency to Bazel. The specific method will depend on the dependency, but tips and tricks have been listed in the document above.
-4. Patch and build the dependency out of band, and then import the built artifacts into the Bazel build.
+3. Migrate said dependency to Bazel. The specific method will depend on the dependency, but tips and tricks have been listed in the document above. We expect most dependencies to fall into this bucket.
+4. Patch and build the dependency out of band, and then import the built artifacts into the Bazel build. This is the least preferred method, because the build of that artifact may not be reproducible. However, once it's built and imported into Bazel, it should conserve hermeticity.
 
 An early draft of documentation explaining these can be found [here](https://github.com/thesayyn/sonic-buildimage/blob/master/tools/bazel/docs/import-external-projects.md).
 
@@ -330,7 +337,7 @@ An early draft of documentation explaining these can be found [here](https://git
 
 Currently, most components in SONiC are bundled into `.deb` archives before being installed in the containers to be deployed.
 
-We propose a similar model except, instead of `.deb` archives, we will bundle the components into tar archives for ease of consumption. Using `tar.bzl` and `mtree`, we can replicate the rootfs structure of `.deb` packages:
+We propose a similar model, except that instead of `.deb` archives, we will bundle the components into tar archives for ease of consumption. Using `tar.bzl` and `mtree`, we can replicate the rootfs structure of `.deb` packages:
 
 ```starlark
 # Example from: https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/src/sonic-sysmgr/BUILD.bazel#L4-L11
@@ -364,6 +371,8 @@ oci_image(
     visibility = ["//visibility:public"],
 )
 ```
+
+If a `.deb` package had install scripts, these will have to be replicated in Bazel _before creating the `tar`_. The `tar` should reflect how the filesystem would look _after_ installing the `.deb`.
 
 ##### 7.b.4 Platform & Device Support
 
@@ -402,15 +411,15 @@ alias(
 Once the build is defined like that, a user that wants to build for Broadcom can specify this from the command line:
 
 ```shell
-$ bazel build //dockers/docker-syncd:docker-syncd --@sonic_build_infra//asic_manufacturer=broadcom
+$ bazel build //dockers/docker-syncd:docker-syncd --@sonic_build_infra//config:asic_manufacturer=broadcom
 ```
 
 We can similarly parameterize every aspect of the build, including which SAI implementation to use:
 
 ```shell
 $ bazel build <target> \
-   --@sonic_build_infra//asic_manufacturer=broadcom
-   --@sonic_build_infra//sai=<your custom SAI implementation>
+   --@sonic_build_infra//config:asic_manufacturer=broadcom \
+   --@sonic_build_infra//config:sai=<your custom SAI implementation>
 ```
 
 For ease of use, we propose bundling default configurations for well-known combinations:
@@ -423,19 +432,62 @@ $ bazel build <target> --config=broadcom # Equivalent to the above.
 
 We will implement automatic debug container generation, mirroring the current system.
 
-We will write a Bazel rule that will crawl the dependency tree of an image, capture the debug symbols of its binaries, and bundle them with well-known debugging tools such as `gdb` to create debug containers.
-
-For instance, following the example in [7.b.4](#7b4-platform--device-support):
+When specifying a component that contains debuggable artifacts, maintainers can replace `tar` with `sonic_deploy_tar` (defined in `sonic_build_infra`):
 
 ```starlark
-oci_image(
-    name = "docker-base-trixie",
+sonic_deploy_tar(
+    name = "hello_deploy_tar",
+    srcs = ["//tests/testdata:file.txt"],
+    binaries = {
+        "./usr/bin/hello uid=0 gid=0 time=1672560000 mode=0755 type=file": ":hello",
+    },
+    force_debug_build = True,
+    mtree = [
+        ". time=946699200 mode=0755 type=dir",
+        ...
+    ],
+)
+```
+
+This rule allows us to do two things:
+- Specify which binaries are supposed to be debuggable, through the `binaries` attribute.
+- Specify whether we should _force Bazel to produce debug builds_ (and therefore have some debug information to bundle in debug containers).
+
+This metadata will be propagated through the Bazel dependency tree, and OCI images will be able to consume it. For instance, if we have the following structure:
+
+```starlark
+sonic_deploy_tar(
+    name = "hello_deploy_tar",
+    binaries = {
+        "./usr/bin/hello uid=0 gid=0 time=1672560000 mode=0755 type=file": ":hello",
+    },
+    force_debug_build = True,
     ...
 )
 
-debug_container(
-	name = "docker-base-trixie_dbg",
-    base = ":docker-base-trixie" # reference the container above
+oci_image(
+    name = "hello_image",
+    tars = [":hello_deploy_tar"],
+    ...
+)
+```
+
+Then we can use the custom `debug_symbols_layer` (also from `sonic_build_infra`) to crawl up the Bazel dependency tree using a [Bazel aspect](https://bazel.build/extending/aspects), gathering all the debug symbols, and then use it as the debug layer of a container:
+
+```starlark
+debug_symbols_layer(
+    name = "hello_image.debug_symbols",
+    image = ":hello_image",
+)
+
+oci_image(
+    name = "hello_image.debug",
+    base = ":hello_image",
+    tars = [
+        "//tools/bazel:debug_utils_pkg",  # <=== Package containing gdb, vim, etc.
+        ":hello_image.debug_symbols",
+    ],
+    ...
 )
 ```
 
@@ -474,7 +526,7 @@ There are no changes to the configuration.
 
 ### 10. Warmboot and Fastboot Design Impact  
 
-This design doesn't impact warmboot
+This design doesn't impact warmboot.
 
 ### 11. Memory Consumption
 
@@ -485,12 +537,14 @@ We expect the resulting containers to be comparable (if not equal) to those prod
 We should not depend on the host system at all. This means that we must find hermetic alternatives to historically unhermetic software, such as gcc. For instance, we should never rely on gcc being installed on the system.
 
 This means that, sometimes, we'll need to migrate dependencies to Bazel, which incurs a non-trivial cost. A large portion of these dependencies have already been migrated, and the maintenance cost is estimated to be low.
+However, this also presents a good opportunity for members of the community to acquire some Bazel experience, which will help the long-term health of the project.
 
 ### 13. Testing Requirements/Design  
 
 There are no new SONiC functional, unit, or system tests required.
 
-However, we will be adding CI jobs to validate the Bazel builds in the required environments, as outlined in the [CI Considerations](#ci-considerations). We expect to be able to leverage remote caching to make these builds significantly more performant than the alternative.
+However, we will be adding CI jobs to validate the Bazel builds in the required environments, as outlined in the [CI considerations](#ci-considerations) section, as well as other equivalence characteristics we need (such as image size, and file layout diffs with the Make-built images).
+We expect to be able to leverage remote caching to make these builds significantly more performant than the alternative.
 
 #### 13.1. Unit Test cases  
 
@@ -499,4 +553,7 @@ However, we will be adding CI jobs to validate the Bazel builds in the required 
 ### 14. Open/Action items - if any 
 
 - **Should we add a per-component toggle during the migration?**
-  - If necessary, it's entirely possible to add a per-target flag, so that individual components can be toggled without affecting the rest of the build. We're not confident that the feature is needed, and the effort to implement it is relatively low, therefore we've left it out of this document.
+    - If necessary, it's entirely possible to add a per-target flag, so that individual components can be toggled without affecting the rest of the build. We're not confident that the feature is needed, and the effort to implement it is relatively low, therefore we've left it out of this document.
+
+- **If we stand up a public remote cache, how would the hosting and trust models work?**
+    - This area has extensive prior art, but a rough sketch would be that the cache would be hosted in current Azure infrastructure, and only CI jobs are allowed to write to it.

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -184,6 +184,9 @@ One open question is when we will establish a blocking CI pipeline for Bazel bui
 We propose the following structure:
 
 - At the beginning of Phase 1: A nightly, post-merge job that tests the Bazel builds only. There are no expectations to keep this job green, but it will be useful in spotting regressions.
+- Throughout Phase 1:
+    - We will add tests to the Bazel CI pipeline to ensure that Bazel and Make produce similar-enough artifacts. We define similar-enough as "produce the same file names in the same locations with the same permissions". We cannot check that the files are byte-by-byte equivalent, because the Make-based build system is less hermetic than Bazel.
+    - The build working group will keep an eye on changes to the Make-based build system, and try to incorporate them into the Bazel system quickly. This will prevent technical debt from building up in preparation for Phase 2.
 - At the beginning of Phase 2: Bazel builds are blocking pre-submit. When we flip the default of `BUILD_WITH_BAZEL_WHEN_AVAILABLE`, the components that are migrated to Bazel will now be blocking the pre-submit checks.
 
 This phased approach allows us to establish critical infrastructure and let the build mature before we make it required for anyone.
@@ -557,3 +560,6 @@ We expect to be able to leverage remote caching to make these builds significant
 
 - **If we stand up a public remote cache, how would the hosting and trust models work?**
     - This area has extensive prior art, but a rough sketch would be that the cache would be hosted in current Azure infrastructure, and only CI jobs are allowed to write to it.
+
+- **How should we handle dependencies like `snapshot.debian.org`, and the BCR?**
+    - These are static repositories of archives. Sometimes, they are not reliable. A shared community instance of a service like Artifactory would help paper over the reliability issues, but we should discuss how to host and run an instance like that.

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -41,20 +41,32 @@
 
 This document covers the migration of the SONiC build system into a modern, Bazel-based system. It proposes an end state of the build system, as well as a migration path to get us there.
 
-Please note that this design covers only the migration of individual components. Migrating the full image assembly process is out of the scope of this document.
+Please note that this design covers only the migration of individual components (defined in the next section). Migrating the full image assembly process is out of the scope of this document.
 
 ### 3. Definitions/Abbreviations
 
+Core Definitions
+
+- Component: When we reference "SONiC components" here, we're generally talking about "a unit of work that can exist and be built in isolation".
+    - For this document, it is useful to think of components as "pieces of functionality that would make sense to migrate at once".
+    - A useful heuristic to figure out what is and isn't a component is to look at `<sonic-buildimage>/rules/*.mk`. If it has an `*.mk` file, we'll likely call it a component.
+    - First party `.deb` files, first party wheels (e.g. `sonic-utilities`), and containers are components. The tests for `sonic-swss` are _not_ a component.
+
+Bazel Definitions
+
 - Bazel: A build system open-sourced by Google. It specializes in polyglot builds, and promises fast, reproducible builds through hermeticity. [Documentation](https://bazel.build/docs)
-- Bazel rules, also called rulesets: Extensions to Bazel to provide additional capabilities, usually to integrate Bazel with a new programming language. Usually named `rules_<lang>`. For instance, `rules_go` extends Bazel to be able to build and test Go sources. [Documentation](https://bazel-docs-staging.netlify.app/versions/master/skylark/rules.html)
-- BUILD files: Files where the Bazel build is defined. Usually named `BUILD.bazel`, and written by hand in [Starlark](https://bazel.build/rules/language). [Documentation](https://bazel.build/concepts/build-files)
-- Bazel registry: A specially-shaped directory that hosts bazel rules and their versions. [Documentation](https://bazel.build/external/registry)
-- Bazel Central Registry, or BCR: The canonical, Google-maintained Bazel registry. Most rulesets live here, and most Bazel projects pull their rulesets from here. [Documentation](https://registry.bazel.build/)
-- bzlmod: Bazel's dependency resolution tool, which takes care of resolving ruleset dependencies. Automatically works with the BCR by default, but can be configured to resolve dependencies from other Bazel registries. [Documentation](https://bazel.build/external/overview)
 - Bazel target: The unit of a build. A target represents one or more inputs and produces one or more outputs. For instance, "the docker image for syncd" is a target, but so is "the shared library of sonic_swss_common". [Documentation](https://bazel.build/concepts/build-ref)
 - Label: The unique identifier of a target. It follows the syntax `@<repository name>//path/to/target:<target name>` . For instance, `@sonic_buildimage//dockers/docker-base-bookworm:docker-base-bookworm` refers to [this target](https://github.com/thesayyn/sonic-buildimage/blob/04f2d3bf54650b1ceecb663a11f53be6810856f1/dockers/docker-base-bookworm/BUILD.bazel#L123-L139). [Documentation](https://bazel.build/concepts/labels)
+- Bazel rules, also called rulesets: Extensions to Bazel to provide additional capabilities, usually to integrate Bazel with a new programming language. Usually named `rules_<lang>`. For instance, `rules_go` extends Bazel to be able to build and test Go sources. Over time, more of the basic Bazel capabilities have migrated into rules (e.g. `rules_java`) [Documentation](https://bazel-docs-staging.netlify.app/versions/master/skylark/rules.html)
+- BUILD files: Files where the Bazel build is defined. Usually named `BUILD.bazel`, and written by hand in [Starlark](https://bazel.build/rules/language). [Documentation](https://bazel.build/concepts/build-files)
+- Bazel registry: A specially-shaped directory that hosts bazel rules and their versions. [Documentation](https://bazel.build/external/registry)
+    - A registry can be hosted either in the local filesystem, or in an HTTP server (e.g. a GitHub repository).
+    - A registry always hosts Bazel rules. If a Bazel module looks to be something else, it's usually because it hosts _the Bazel BUILD files for that module_. For instance, the module [`@openssl`](https://registry.bazel.build/modules/openssl) in the Bazel Central Registry hosts [BUILD files](https://registry-preview.bazel.build/modules/openssl/3.5.5.bcr.4/overlay), not C files. The source code of OpenSSL itself is fetched at [build time, usually via `http_archive`](https://github.com/bazelbuild/bazel-central-registry/blob/68775ed7998a241462b0db593673b8277f407ba2/modules/openssl/3.5.5.bcr.4/overlay/MODULE.bazel#L18-L25).
+- Bazel Central Registry, or BCR: The canonical, Google-maintained Bazel registry. Most rulesets live here, and most Bazel projects pull their rulesets from here. [Documentation](https://registry.bazel.build/)
+- bzlmod: Bazel's dependency resolution tool, which takes care of resolving ruleset dependencies. Automatically works with the BCR by default, but can be configured to resolve dependencies from other Bazel registries. [Documentation](https://bazel.build/external/overview)
 
-Non-Bazel Definitions
+Non-Bazel Definitions:
+
 - debhelper, or `dh`: A suite of Debian tools to rebuild and repack Debian packages. In SONiC, they are used to apply patches to external dependencies. [Documentation](https://man7.org/linux/man-pages/man1/dh.1.html)
 - Open Container Initiative (OCI): An industry standard to specify container formats and runtimes. [Documentation](https://opencontainers.org/).
 
@@ -84,7 +96,7 @@ Early results demonstrate that we can produce cold builds similar to those in th
 
 Bazel migrations are expensive, and famously disruptive. To alleviate this issue as much as possible, we propose a gradual, non-mandatory rollout.
 
-We will **extend the existing build system** with a new target type that can build docker containers in Bazel.
+We will **extend the existing build system** with a new makefile target type that can build docker containers in Bazel.
 The mechanics of this new target are discussed in [7.a](#7a-changes-to-existing-build-system-bazelmake-interoperability).
 
 Users can control whether they want to build with Bazel or GNU make with a command line flag:
@@ -103,34 +115,42 @@ To minimize disruption, we propose the following phases to the migration:
 
 ##### Phase 1: Trial of Bazel Infrastructure
 
-Phase 1 will introduce Bazel as an optional build system for some components. The goal is to validate whether and how SONiC could most benefit from Bazel.
+Phase 1 will introduce Bazel as an optional build system for some components.
+The goal is to validate whether and how SONiC could most benefit from Bazel.
 
 For this phase, `BUILD_WITH_BAZEL_WHEN_AVAILABLE` will be turned off by default.
-We will start adding Bazel builds for leaf, small components such as `sysmgr`, `p4rt`, and the small watchdog binaries, and continue onto progressively larger leaf components until we have sufficient coverage to be representative of the benefits and challenges that Bazel poses.
+We will aim to migrate entire containers at once, though it's possible that a container can have _some_ Bazel-built parts and some Make-built parts.
+We will start adding Bazel builds for leaf, small containers such as `sysmgr`, `p4rt`, and the small watchdog binaries, and continue onto progressively larger leaf containers until we have sufficient coverage to be representative of the benefits and challenges that Bazel poses.
 
-All components should still be buildable with the regular Make-based flow.
+All components (containers and individual `.deb`s) should still be buildable with the regular Make-based flow.
 
-When a component is built with Bazel, this will entail:
+When a container is built with Bazel, this will entail:
 
-- Eliminating system dependencies for that component (e.g. from `apt` and `whl`), as well as other sonic-make injected deps. All dependencies will go through the hermetic Bazel build graph.
-- Removing `deb` packages as an intermediate format for that component, instead relying on the Bazel dependency graph.
-- Removing `docker` as a dependency for that component, instead building containers directly with Bazel.
+- Eliminating system dependencies for that container (e.g. from `apt` and `whl`), as well as other sonic-make injected deps. All dependencies will go through the hermetic Bazel build graph.
+- Removing `deb` packages as an intermediate format for that container, instead relying on the Bazel dependency graph. We will retain the ability to create `deb` packages with Bazel, it will just not be required.
+- Removing `docker` as a dependency for that container, instead building containers directly with Bazel.
 
 However, we will not attempt to:
 
-- Build a component with Bazel outside of the SONiC Make infra, or outside the slave container. The interface for users will still be `make target/dockers-*.gz`.
-- Build the base layers in Bazel. Bazel will consume Make-built base layers (e.g. `docker-base-bookworm`, `config-engine`).
-
-**We expect this phase to last until the November release.**
+- Build a container with Bazel outside of the SONiC Make infra, or outside the slave container. The interface for users will still be `make target/dockers-*.gz`.
+- Build the base layers in Bazel. Bazel will consume Make-built base layers (e.g. `docker-base-trixie`, `config-engine`).
 
 The community can use this period to experiment with Bazel, adopt it into their own builds, and generally gather information on whether this is a net benefit.
+We will use this period to gather feedback and craft a list of requirements and exit criteria, answering the question: What guarantees do we need to proceed to Phase 2? What user journeys are the right ones for developers, CI, deployment and so forth?
+We will attempt to formalize them, and fill any gaps during Phase 1.
+
+**We expect this phase to last until the November release.**
 
 After the November release, the community will face a decision point: Should Bazel be a first-class build system in SONiC?
 
 Specifically:
 
-- Should Bazel be allowed to be the _only option_ for certain components (like it is today for `p4rt`)?
-- Should Bazel be allowed to handle most of the dependency graph for these components? As a consequence, some SONiC dependencies will have to be converted to Bazel (e.g. `sonic-utilities`).
+- Is the development experience in Bazel supported well enough to be used in day-to-day operations for migrated components and containers?
+    - Are there any gaps left to fill before this is true?
+- Should Bazel be allowed to be the _only option_ for certain containers (like it is today for `p4rt`)?
+- Should Bazel be allowed to handle most of the dependency graph for these containers? As a consequence, some SONiC dependencies will have to be converted to Bazel (e.g. `sonic-utilities`).
+
+If we decide there are still gaps, we will work to correct them before proceeding.
 
 If we decide to move forward, we will continue onto Phase 2.
 
@@ -162,7 +182,7 @@ One open question is when we will establish a blocking CI pipeline for Bazel bui
 We propose the following structure:
 
 - Phase 1: A nightly, post-merge job that tests the Bazel builds only. There are no expectations to keep this job green, but it will be useful in spotting regressions.
-- Phase 2: Bazel builds are blocking pre-submit. When we flip the default of `BUILD_WITH_BAZEL_WHEN_AVAILABLE`, the components that are migrated to Bazell will now be blocking the pre-submit checks.
+- Phase 2: Bazel builds are blocking pre-submit. When we flip the default of `BUILD_WITH_BAZEL_WHEN_AVAILABLE`, the components that are migrated to Bazel will now be blocking the pre-submit checks.
 
 This phased approach allows us to establish critical infrastructure and let the build mature before we make it required for anyone.
 
@@ -196,7 +216,7 @@ The migration must satisfy the following requirements:
 
 There are no expected changes to the SONiC component architecture.
 
-However, we will extende the SONiC build architecture to add a new target type for containers (read more in [Section 7.a](#7a-changes-to-existing-build-system-bazelmake-interoperability)).
+However, we will extend the SONiC build architecture to add a new target type for containers (read more in [Section 7.a](#7a-changes-to-existing-build-system-bazelmake-interoperability)).
 
 In addition, some of the existing dependency graph for libraries, binaries, and third party dependencies will move into Bazel.
 
@@ -206,30 +226,34 @@ This section specifies how different parts of the build will work under Bazel.
 Everything explained here has already been implemented in a proof of concept migrating `docker-sysmgr`, in [sonic-buildimage#28005](https://github.com/sonic-net/sonic-buildimage/pull/28005).
 The following sections will explain different parts of that PR.
 
+> [!warning]
+> At the time of writing, development of the PR had been done in Bookworm.
+> Since then, SONiC changed to be Trixie-only.
+> We will migrate the PR to be Trixie-only before submitting it for review,
+> but please note that some of the code links may not match the text, and still mention Bookworm.
+
 #### 7.a Changes to Existing Build System (Bazel/make Interoperability)
 
 During the migration, Bazel and make will have to interoperate. This section explains the changes needed in the current build system to make that happen.
 
 We propose to **extend the existing build system to add the ability to build some targets with Bazel**. For example, with [docker-sysmgr](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/rules/docker-sysmgr.mk#L21-L30):
 
-```make
+```diff
 # From sonic-buildimage#28005/rules/docker-sysmgr.mk
 
 ...
-ifeq ($(BUILD_WITH_BAZEL_WHEN_AVAILABLE),n)
-
++ifeq ($(BUILD_WITH_BAZEL_WHEN_AVAILABLE),n)
++
 SONIC_DOCKER_IMAGES += $(DOCKER_SYSMGR)
 SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_SYSMGR)
-
-else
-
-# When BUILD_WITH_BAZEL_WHEN_AVAILABLE is enabled, build this docker with Bazel.
-# Bazel only supports bookworm today, which is enforced at the root Makefile.
-$(DOCKER_SYSMGR)_BAZEL_BASE += $(DOCKER_CONFIG_ENGINE_BOOKWORM)
-SONIC_BAZEL_DOCKER_IMAGES += $(DOCKER_SYSMGR)
-SONIC_BOOKWORM_DOCKERS += $(DOCKER_SYSMGR)
-
-endif
++
++else
++
++$(DOCKER_SYSMGR)_BAZEL_BASE += $(DOCKER_CONFIG_ENGINE_TRIXIE)
++SONIC_BAZEL_DOCKER_IMAGES += $(DOCKER_SYSMGR)
++SONIC_TRIXIE_DOCKERS += $(DOCKER_SYSMGR)
++
++endif
 ...
 ```
 
@@ -280,7 +304,7 @@ This section describes how individual components are built with Bazel, focusing 
 The Bazel ethos is that **every input to a build must be known, down to the checksum, before the build starts**. The current build system has a few instances where we cannot deterministically predict these inputs.
 
 - Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](https://github.com/blorente/sonic-build-infra/tree/master/toolchains/gcc).
-- Fetch Debian packages deterministically, instead of relying on `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/MODULE.bazel#L23-L56).
+- Fetch Debian packages deterministically, instead of relying on `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/MODULE.bazel#L23-L56). Please note that this only refers to the Bazel ruleset, and is **unrelated to distroless containers** as a concept. Switching to distroless containers is out of the scope of this document.
 
 > [!warning]
 > During the transition, Bazel will consume base layers from the Make-based build. This can lead to discrepancies in runtime dependencies if we don't keep the `rules_distroless` dependencies up to date.
@@ -296,7 +320,7 @@ We propose four approaches to tackle this problem. They are detailed in [this do
 In order of most preferred to least preferred, they are:
 
 1. Find the module we want to patch in the BCR. Please see the PR for instructions on how to patch it.
-2. Pull the dependency as a Debian package with `rules_distroless`. This method does not allow patching.
+2. Pull the dependency as a Debian package with `rules_distroless`. This method does not build the dependencies from source, and thus **does not allow patching**.
 3. Migrate said dependency to Bazel. The specific method will depend on the dependency, but tips and tricks have been listed in the document above.
 4. Patch and build the dependency out of band, and then import the built artifacts into the Bazel build.
 
@@ -405,13 +429,13 @@ For instance, following the example in [7.b.4](#7b4-platform--device-support):
 
 ```starlark
 oci_image(
-    name = "docker-base-bookworm",
+    name = "docker-base-trixie",
     ...
 )
 
 debug_container(
-	name = "docker-base-bookworm_dbg",
-    base = ":docker-base-bookworm" # reference the container above
+	name = "docker-base-trixie_dbg",
+    base = ":docker-base-trixie" # reference the container above
 )
 ```
 
@@ -460,7 +484,7 @@ We expect the resulting containers to be comparable (if not equal) to those prod
 
 We should not depend on the host system at all. This means that we must find hermetic alternatives to historically unhermetic software, such as gcc. For instance, we should never rely on gcc being installed on the system.
 
-This means that, sometimes, we'll need to migrated dependencies to Bazel, which incurs a non-trivial cost. A large portion of these dependencies have already been migrated, and the maintenance cost is estimated to be low.
+This means that, sometimes, we'll need to migrate dependencies to Bazel, which incurs a non-trivial cost. A large portion of these dependencies have already been migrated, and the maintenance cost is estimated to be low.
 
 ### 13. Testing Requirements/Design  
 

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -75,6 +75,7 @@ Non-Bazel Definitions:
 We have already implemented large parts of this document as proofs of concept.
 
 Please see these publications about our work:
+- Talk from OCP SONiC Workshop 2025: https://www.youtube.com/watch?v=1YNmuzMqV24
 - Talk from OCP EMEA Summit 2026: https://www.youtube.com/watch?v=uSKCNDWuXjc
 - Blog article about our work: https://aspect.build/blog/bazel-for-sonic
 

--- a/doc/bazel/bazel_migration_hld.md
+++ b/doc/bazel/bazel_migration_hld.md
@@ -186,6 +186,9 @@ We propose the following structure:
 - At the beginning of Phase 1: A nightly, post-merge job that tests the Bazel builds only. There are no expectations to keep this job green, but it will be useful in spotting regressions.
 - Throughout Phase 1:
     - We will add tests to the Bazel CI pipeline to ensure that Bazel and Make produce similar-enough artifacts. We define similar-enough as "produce the same file names in the same locations with the same permissions". We cannot check that the files are byte-by-byte equivalent, because the Make-based build system is less hermetic than Bazel.
+    - We will also add a checks to handle version drift:
+        - Changes in versions of third party dependencies (Bazel modules, apt deps, or Python deps) will be flagged by a CI job.
+        - Whenever a version of a third party dependency differs between Bazel and Make (in `files/build/versions-public/build/build-sonic-slave-trixie`), the CI job will fail.
     - The build working group will keep an eye on changes to the Make-based build system, and try to incorporate them into the Bazel system quickly. This will prevent technical debt from building up in preparation for Phase 2.
 - At the beginning of Phase 2: Bazel builds are blocking pre-submit. When we flip the default of `BUILD_WITH_BAZEL_WHEN_AVAILABLE`, the components that are migrated to Bazel will now be blocking the pre-submit checks.
 
@@ -313,6 +316,7 @@ As part of preparing the repository for the migration, we have done the followin
 
 - Define a hermetic gcc toolchain, so that we always use the same version for every build. [Source](https://github.com/blorente/sonic-build-infra/tree/master/toolchains/gcc). The toolchain will be chosen to be compatible with the apt packages downloaded for that Debian version. The one in the source, for instance, is ABI-compatible with Bookworm. This version can be changed as we discover more facts. For instance, if we discover that we need a more specific gcc to maintain ABI compatibility for a particular vendor's SAI implementation, we can generate new toolchains at will through [blorente/gcc-builds](https://github.com/blorente/gcc-builds).
 - Fetch Debian packages deterministically, instead of relying on `apt install`. We do that by using `rules_distroless` to fetch from a Debian snapshot. [Source](https://github.com/sonic-net/sonic-buildimage/blob/e09be005b19c3521c674e4415d08a25648fc15f4/MODULE.bazel#L23-L56). Please note that this only refers to the Bazel ruleset, and is **unrelated to distroless containers** as a concept. Switching to distroless containers is out of the scope of this document.
+- Centralize Python and `apt` third-party dependencies into `@sonic-build-infra//deps` (which lives in `<sonic-buildimage>/src/sonic-build-infra/deps`), for easy reference. Components will have to use dependencies from this centralized list (they won't be able to fetch their own Python and `apt` dependencies).
 
 > [!warning]
 > During the transition, Bazel will consume base layers from the Make-based build. This can lead to discrepancies in runtime dependencies if we don't keep the `rules_distroless` dependencies up to date.


### PR DESCRIPTION
Add HLD describing a potential migration to Bazel, including the changes necessary in the current build so that the migration is as un-disruptive as possible.