### PR TITLE
doc/acl: document the PACKET_COLOR_ACTION ACL rule action

### DIFF
--- a/doc/acl/ACL-High-Level-Design.md
+++ b/doc/acl/ACL-High-Level-Design.md
@@ -1,6 +1,6 @@
 # ACL in SONiC
 # High Level Design Document
-### Rev 1.1
+### Rev 1.2
 
 # Table of Contents
   * [List of Tables](#list-of-tables)
@@ -88,6 +88,7 @@
 | 0.3 | 10-Nov-2016 | Andriy Moroz       | Updated according to the comments   |
 | 0.4 | 20-Dec-2016 | Oleksandr Ivantsiv | Update data structures              |
 | 1.1 | 08-Apr-2025 | Anish Narsian      | VXLAN inner src mac rewrite support |
+| 1.2 | 01-Jul-2026 | Anant Kishor Sharma | PACKET_COLOR_ACTION (set packet color) ACL rule action |
 # About this Manual
 This document provides general information about the ACL feature implementation in SONiC.
 # Scope
@@ -568,6 +569,25 @@ to class AclRuleMirror to indicate the stage the ACL mirror rule, according to t
 action, "SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS" for ingress ACL rule, "SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_EGRESS"
 for egress ACL rule.  
 Add possibility to receive updates about mirror sessions state change and perform mirroring rules state change accordingly.
+
+To set the packet color of ACL-matched traffic, the packet color action (keyword "PACKET_COLOR_ACTION") is realized by
+class "AclRulePacket", which maps the configured color "GREEN"/"YELLOW"/"RED" to the SAI enum values
+"SAI_PACKET_COLOR_GREEN"/"SAI_PACKET_COLOR_YELLOW"/"SAI_PACKET_COLOR_RED" and programs
+"SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR" on the ACL entry. The action is gated by the per-stage ASIC action
+capability that is queried at startup and published in STATE_DB "ACL_STAGE_CAPABILITY_TABLE": it is available on any
+stage (ingress and/or egress) whose SAI advertises "SAI_ACL_ACTION_TYPE_SET_PACKET_COLOR", and a table or rule that
+uses it is rejected on platforms that do not advertise it, so there is no behavior change for existing platforms. The
+action is handled in the generic CONFIG_DB ACL pipeline (previously "SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR" was
+only reachable via the P4Orch/P4RT path).
+
+Because setting the packet color only marks the matched packet's drop precedence (consumed downstream by a
+color-aware policer or WRED) and neither forwards nor drops it, "PACKET_COLOR_ACTION" is an additive
+(composable) action rather than an exclusive one: a rule may carry it alone -- the matched packet keeps its
+normal forwarding path and simply carries the assigned color -- or combine it with a single forwarding action
+(e.g. "FORWARD"/"DROP") and/or a counter on the same rule. Accordingly "AclRulePacket::validate()" excludes
+"SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR" from its single exclusive-action check. Setting the color updates
+internal drop precedence only; it does not modify DSCP or PCP directly (those change on egress only when a
+"TC_AND_COLOR_TO_DSCP"/"TC_AND_COLOR_TO_DOT1P" QoS map is configured).
 # 4 Flows
 ## 4.1 Creating of ACL Objects
 ![](acl_create.png)
@@ -629,6 +649,7 @@ Ansible + PTF
 |packet_action | ACL Rule property. Packet actions "forward" or "drop". Valid for rules in "L3" tables only
 |mirror_action | Action "mirror". Valid for rules in "mirror" tables only
 |inner_src_mac_rewrite_action | Action to rewrite the inner src mac rewrite field.
+|packet_color_action | Action to set the packet color ("GREEN"/"YELLOW"/"RED") on matching packets. Maps to SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR
 *Keywords derived from the SAI ACL attributes.*
 # Appendix B: Sample input json file
 ```


### PR DESCRIPTION
#### What I did
Document the `PACKET_COLOR_ACTION` ACL rule action in the ACL High Level Design, matching how the existing ACL rule actions (`packet_action`, `mirror_action`, `inner_src_mac_rewrite_action`) are documented.

`PACKET_COLOR_ACTION` (`GREEN`/`YELLOW`/`RED`) maps to `SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR` in the generic CONFIG_DB `AclOrch` pipeline. It is capability-gated per ACL stage (ingress and/or egress) and is a no-op on platforms whose SAI does not advertise the action.

#### Details
- `Rev 1.1 -> 1.2` + revision-history row
- Design paragraph: `AclRulePacket`, the `GREEN`/`YELLOW`/`RED` -> `SAI_PACKET_COLOR_*` mapping, and the per-stage capability gating (`ACL_STAGE_CAPABILITY_TABLE`)
- Appendix keyword-table row for `packet_color_action`

Note: this overlaps with the in-flight #2423 (policer HLD) on the revision number and tables; whichever merges first, I'll rebase the other (bump to 1.3).

---
Related PRs:

| Repo | PR title | State |
| ---- | -------- | ----- |
| sonic-swss | [aclorch: Support SET_PACKET_COLOR ACL action](https://github.com/sonic-net/sonic-swss/pull/4717) | ![state](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-swss/4717) |
| sonic-buildimage | [sonic-yang-models: Add PACKET_COLOR_ACTION to sonic-acl YANG](https://github.com/sonic-net/sonic-buildimage/pull/28151) | ![state](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-buildimage/28151) |
