### PR TITLE
[doc/acl]: Add TC_ACTION (set traffic class) ACL rule action

### DIFF
--- a/doc/acl/ACL-High-Level-Design.md
+++ b/doc/acl/ACL-High-Level-Design.md
@@ -1,6 +1,6 @@
 # ACL in SONiC
 # High Level Design Document
-### Rev 1.1
+### Rev 1.2
 
 # Table of Contents
   * [List of Tables](#list-of-tables)
@@ -88,6 +88,7 @@
 | 0.3 | 10-Nov-2016 | Andriy Moroz       | Updated according to the comments   |
 | 0.4 | 20-Dec-2016 | Oleksandr Ivantsiv | Update data structures              |
 | 1.1 | 08-Apr-2025 | Anish Narsian      | VXLAN inner src mac rewrite support |
+| 1.2 | 01-Jul-2026 | Anant Kishor Sharma | TC_ACTION (set traffic class) ACL rule action |
 # About this Manual
 This document provides general information about the ACL feature implementation in SONiC.
 # Scope
@@ -568,6 +569,21 @@ to class AclRuleMirror to indicate the stage the ACL mirror rule, according to t
 action, "SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS" for ingress ACL rule, "SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_EGRESS"
 for egress ACL rule.  
 Add possibility to receive updates about mirror sessions state change and perform mirroring rules state change accordingly.
+
+To set the traffic class (Class-of-Service) of ACL-matched traffic, the traffic class action (keyword "TC_ACTION") is
+realized by class "AclRulePacket", which parses the configured 8-bit value (0-255) and programs it as
+"SAI_ACL_ENTRY_ATTR_ACTION_SET_TC" on the ACL entry. The action is gated by the per-stage ASIC action capability that
+is queried at startup and published in STATE_DB "ACL_STAGE_CAPABILITY_TABLE": it is available on any stage (ingress
+and/or egress) whose SAI advertises "SAI_ACL_ACTION_TYPE_SET_TC", and a table or rule that uses it is rejected on
+platforms that do not advertise it, so there is no behavior change for existing platforms. The action is handled in the
+generic CONFIG_DB ACL pipeline (previously "SAI_ACL_ENTRY_ATTR_ACTION_SET_TC" was only reachable via the P4Orch/P4RT path).
+
+Because setting the traffic class neither forwards nor drops a packet, "TC_ACTION" is an additive
+(composable) action rather than an exclusive one: a rule may carry it alone -- the matched packet keeps its
+normal forwarding path and simply carries the assigned traffic class -- or combine it with a single
+forwarding action (e.g. "FORWARD"/"DROP") and/or a counter on the same rule. Accordingly
+"AclRulePacket::validate()" excludes "SAI_ACL_ENTRY_ATTR_ACTION_SET_TC" from its single exclusive-action
+check.
 # 4 Flows
 ## 4.1 Creating of ACL Objects
 ![](acl_create.png)
@@ -629,6 +645,7 @@ Ansible + PTF
 |packet_action | ACL Rule property. Packet actions "forward" or "drop". Valid for rules in "L3" tables only
 |mirror_action | Action "mirror". Valid for rules in "mirror" tables only
 |inner_src_mac_rewrite_action | Action to rewrite the inner src mac rewrite field.
+|tc_action | Action to set the traffic class (Class-of-Service), an 8-bit value 0-255, on matching packets. Maps to SAI_ACL_ENTRY_ATTR_ACTION_SET_TC
 *Keywords derived from the SAI ACL attributes.*
 # Appendix B: Sample input json file
 ```


### PR DESCRIPTION
#### Why I did it
Document the new `TC_ACTION` ACL rule action (set traffic class) in the ACL High Level Design.

#### How I did it
- Bump revision 1.1 -> 1.2 and add a revision-history row.
- Add a design paragraph describing `TC_ACTION` -> `SAI_ACL_ENTRY_ATTR_ACTION_SET_TC` (realized by `AclRulePacket`, gated by the per-stage ASIC action capability published in STATE_DB `ACL_STAGE_CAPABILITY_TABLE`, with no behavior change for existing platforms), plus a paragraph on its composability: an additive action that `AclRulePacket::validate()` excludes from the single exclusive-action check, so a rule may set the traffic class alone or together with a forwarding action and/or a counter.
- Add the `tc_action` keyword to Appendix A.

---
Related PRs:

| Repo | PR title | State |
| ---- | -------- | ----- |
| sonic-swss | [aclorch: Support SET_TC (traffic class) ACL rule action](https://github.com/sonic-net/sonic-swss/pull/4726) | ![state](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-swss/4726) |
| sonic-buildimage | [sonic-yang-models: Add TC_ACTION to sonic-acl](https://github.com/sonic-net/sonic-buildimage/pull/28193) | ![state](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-buildimage/28193) |
| sonic-mgmt | [tests: SET_TC (TC_ACTION) ACL rule action](https://github.com/sonic-net/sonic-mgmt/pull/26099) | ![state](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-mgmt/26099) |
