### PR TITLE
HLD - Audit Logging daemon for command tracking and RADIUS accounting

### DIFF
--- a/doc/radius/radius_aaa_hld.md
+++ b/doc/radius/radius_aaa_hld.md
@@ -1,0 +1,210 @@
+# High-Level Design: RADIUS Authentication & Accounting on SONiC
+
+**Base assumptions**: This document describes the extensions layered on top of the existing upstream RADIUS user-authentication support in SONiC (PAM + NSS via `libnss-radius`, base `RADIUS` / `RADIUS_SERVER` CONFIG_DB tables rendered by `hostcfgd`). Upstream mechanics are not re-described here.
+
+---
+
+## 1. Motivation
+
+Upstream SONiC supports RADIUS-based login authentication but has three gaps that this design closes:
+
+1. **AAA vs. 802.1x server segregation** — no way to say "this RADIUS server is only for admin login, that one is only for host authentication."
+2. **VRF binding for RADIUS accounting** — RADIUS traffic on the management network requires the daemon speaking RADIUS to bind its socket into the `mgmt` VRF.
+3. **Command / audit accounting** — there is no daemon that streams a switch's audit trail (privileged commands, `auditd` records) to a central RADIUS server as Accounting-Requests.
+
+This design adds the three capabilities above while reusing all of the upstream RADIUS scaffolding for user login.
+
+---
+
+## 2. Scope
+
+**In-scope (this design)**:
+
+- New per-server `usage_scope` field (`all` / `aaa_only` / `dot1x_only`) in `RADIUS_SERVER`, and its consumers in `hostcfgd` and `auditlogd`.
+- New per-server `vrf` field in `RADIUS_SERVER`, plus a global RADIUS passkey, and their consumers in the accounting path.
+- New `auditlogd` daemon in `sonic-host-services` that streams `auditd` events to RADIUS servers as Accounting-Requests.
+- `hostcfgd` extensions for AAA authentication policy (order, fail-through, local fallback) so login and accounting share coherent policy.
+
+**Out-of-scope (untouched or upstream)**:
+
+- Base RADIUS login authentication via PAM / NSS (upstream behavior, reused as-is).
+- Existing `RADIUS` global fields (`auth_type`, `passkey`, `timeout`, `retransmit`, `nas_ip`, `src_intf`) — described here only where new consumers reference them.
+- 802.1x / PAC / hostapd / `wpa_supplicant` integration.
+- TACACS+ integration.
+- TLS transport for RADIUS (RADSEC / RADIUS-over-DTLS).
+
+---
+
+## 3. Feature Overview
+
+Two new consumers read the shared RADIUS configuration model and speak to the RADIUS infrastructure:
+
+```
+                        +---------------------------+
+   SSH / console  --->  |  hostcfgd renders PAM/NSS |  <---> RADIUS server(s)  (Auth)
+   (admin login)        |  filtered by usage_scope  |        usage_scope in {all, aaa_only}
+                        +---------------------------+
+
+                        +---------------------------+
+   audit events  --->   |  auditlogd (new daemon)   |  <---> RADIUS server(s)  (Acct)
+   (auditd -> netlink)  |  RADIUS Accounting client |        usage_scope in {all, aaa_only}
+                        +---------------------------+
+
+                Configuration source: CONFIG_DB::RADIUS + RADIUS_SERVER
+                (existing tables, extended with `usage_scope` and `vrf`)
+```
+
+`hostcfgd` is the sole renderer of RADIUS-related on-disk configuration. `auditlogd` is a new systemd service supplied by `sonic-host-services-data`.
+
+---
+
+## 4. Data Model (CONFIG_DB) — Additions Only
+
+Only the newly added fields are documented here. The existing `RADIUS` and `RADIUS_SERVER` schemas remain as upstream.
+
+### 4.1 `RADIUS` (global) — new consumers of the existing `passkey`
+
+The upstream global `passkey` is now also consumed by `auditlogd` as the RADIUS shared secret when a server has not defined its own per-server passkey.
+
+### 4.2 `RADIUS_SERVER|<host>` — new fields
+
+| Field           | Type   | Notes                                                                                                                            |
+|-----------------|--------|----------------------------------------------------------------------------------------------------------------------------------|
+| **`vrf`**       | string | VRF name (typically `mgmt`) that RADIUS traffic is sourced from. Consumed by `auditlogd` to bind its accounting socket.          |
+| **`usage_scope`** | enum | `all` / `aaa_only` / `dot1x_only`. Selects which subsystem(s) may use this server. Consumed by both `hostcfgd` and `auditlogd`. |
+
+`usage_scope` semantics used by this design:
+
+- Login AAA (via `hostcfgd`-rendered PAM/NSS) uses servers with `all` or `aaa_only`.
+- Accounting (`auditlogd`) uses servers with `all` or `aaa_only` — dot1x-only servers are excluded so that administrator command audit trails are never sent to end-host RADIUS servers.
+- `dot1x_only` servers are ignored by both consumers described in this design.
+
+The upstream per-server `timeout` and `retransmit` fields, previously used only by the PAM login path, are now also honored by `auditlogd` (see §5.2).
+
+---
+
+## 5. Component Design
+
+### 5.1 `hostcfgd` extensions
+
+`hostcfgd` already renders `/etc/pam.d/*` and `/etc/nsswitch.conf` from `RADIUS` / `RADIUS_SERVER`. This design adds three new behaviors:
+
+- **`usage_scope`-aware rendering** — when rendering the login (PAM/NSS) configuration, `hostcfgd` filters `RADIUS_SERVER` entries to those with `usage_scope ∈ {all, aaa_only}`.
+- **VRF normalization** — when a server declares a `vrf`, that value is surfaced to downstream consumers (`auditlogd`) via the shared configuration surface.
+- **AAA authentication policy** — a new authentication-policy configuration (order, fail-through, local fallback) is honored so that both the login path and `auditlogd` operate under coherent, explicit policy rather than implicit defaults.
+
+### 5.2 `auditlogd` — new RADIUS Accounting daemon
+
+`auditlogd` is a new daemon shipped by `sonic-host-services-data`. It subscribes to Linux `auditd` events over netlink, formats each event as a RADIUS Accounting-Request, and sends it to every enabled RADIUS server.
+
+```
+    auditd  --(netlink AUDIT)-->  auditlogd  --(RADIUS Acct-Request UDP)-->  radius_server
+                                     |
+                                     +-- reads RADIUS / RADIUS_SERVER from CONFIG_DB
+                                     +-- filters by usage_scope in {all, aaa_only}
+                                     +-- binds socket to `vrf` (e.g. mgmt)
+                                     +-- retransmit / timeout / throttling
+                                     +-- STATE_DB status
+```
+
+Packaging:
+
+- A systemd unit `auditlogd.service` shipped by `sonic-host-services-data`.
+- A Python daemon (`scripts/auditlogd`) with an internal `RadiusAccountingClient`.
+- A pytest suite covering netlink handling, RADIUS packet formatting, mgmt-IP / patterns, throttle behavior, and VRF/passkey behavior.
+
+Behaviors introduced by this design:
+
+- **`usage_scope` filter** — an accounting log fans out only to servers with `usage_scope ∈ {all, aaa_only}`. Prevents administrator audit records from being sent to dot1x-only servers.
+- **VRF binding + global passkey** — the RADIUS accounting socket is bound to the server's `vrf`; the global `RADIUS|global` `passkey` is used unless the server defines its own. A consecutive-failure threshold avoids false-positive server-down declarations.
+- **RFC-correct retransmit** — retries reuse the **same** RADIUS Identifier and packet contents, waiting `timeout` seconds between attempts (e.g. `retransmit=2` produces 3 total sends). Per-server `timeout` and `retransmit` from CONFIG_DB are honored; settings are preserved across management-IP updates.
+- **Log throttling** — de-duplicates and rate-limits repeat WARN/ERR log lines (e.g. "Failed to send audit log to RADIUS server X (N consecutive failures)", "Failed to bind to VRF mgmt: [Errno 19]…") so syslog does not flood under sustained failures.
+
+---
+
+## 6. Configuration Example
+
+Only the fields relevant to this design are shown; the rest of the base RADIUS configuration is unchanged from upstream.
+
+```json
+{
+  "RADIUS": {
+    "global": {
+      "passkey": "sonic-shared-secret",
+      "timeout": "5",
+      "retransmit": "2"
+    }
+  },
+  "RADIUS_SERVER": {
+    "10.29.157.71": {
+      "auth_port": "1812",
+      "acct_port": "1813",
+      "priority": "1",
+      "vrf": "mgmt",
+      "usage_scope": "aaa_only",
+      "timeout": "10",
+      "retransmit": "2"
+    },
+    "10.29.157.72": {
+      "auth_port": "1812",
+      "acct_port": "1813",
+      "priority": "2",
+      "vrf": "mgmt",
+      "usage_scope": "dot1x_only"
+    }
+  }
+}
+```
+
+In this configuration, `auditlogd` will send Accounting-Requests only to `10.29.157.71`, binding the socket into VRF `mgmt`, using the global passkey, with a 10-second timeout and two retransmits per event.
+
+---
+
+## 7. Sequence Diagram — Command Audit via `auditlogd`
+
+An operator logs into SONiC via SSH (authenticated by the upstream PAM/NSS RADIUS machinery, which `hostcfgd` renders with `usage_scope` filtering), executes a privileged command, and has that command streamed as a RADIUS Accounting-Request by `auditlogd`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Admin
+    participant SSHD as sshd (+ PAM/NSS)
+    participant HC as hostcfgd
+    participant CDB as CONFIG_DB<br/>(RADIUS / RADIUS_SERVER)
+    participant AUD as auditd
+    participant ALD as auditlogd
+    participant AAAS as RADIUS server<br/>(usage_scope: aaa_only)
+    participant STDB as STATE_DB
+
+    Note over HC,CDB: On boot and on any RADIUS config change
+    HC->>CDB: subscribe(RADIUS, RADIUS_SERVER)
+    CDB-->>HC: config snapshot
+    HC->>SSHD: render PAM / NSS<br/>(only usage_scope in {all, aaa_only})
+    HC->>ALD: expose auditlogd config<br/>(aaa-only servers, vrf, passkey, timeout/retransmit)
+
+    Admin->>SSHD: SSH login
+    SSHD->>AAAS: (upstream PAM/NSS) RADIUS Access-Request via VRF=mgmt
+    AAAS-->>SSHD: Access-Accept
+    SSHD-->>Admin: shell
+
+    Note over Admin,ALD: Admin runs a privileged command
+    Admin->>SSHD: sudo config vlan add 100
+    SSHD->>AUD: audit record (uid, cmd, exit)
+    AUD-->>ALD: netlink AUDIT event
+
+    ALD->>CDB: read RADIUS + RADIUS_SERVER (cached)
+    Note right of ALD: filter servers where<br/>usage_scope in {all, aaa_only}
+    ALD->>AAAS: Accounting-Request<br/>(Acct-Status-Type=Start/Interim/Stop,<br/>User-Name, NAS-Port-Id, ...)<br/>bound to VRF=mgmt
+
+    alt Ack received
+        AAAS-->>ALD: Accounting-Response
+        ALD->>STDB: update auditlogd state (last_ok, counters)
+    else No response within timeout
+        loop retransmit N times (same Identifier)
+            ALD->>AAAS: Accounting-Request (retry)
+        end
+        ALD->>STDB: increment consecutive_failures
+        Note over ALD: throttle repeated<br/>WARN/ERR log lines
+    end
+```
+

--- a/doc/radius/radius_aaa_hld.md
+++ b/doc/radius/radius_aaa_hld.md
@@ -1,45 +1,138 @@
-# High-Level Design: `auditlogd` — RADIUS Accounting for Command Auditing
+# `auditlogd` — Audit Logging Daemon for Command Tracking and RADIUS Accounting
 
-## 1. Overview
+## Table of Content
+
+- [1. Revision](#1-revision)
+- [2. Scope](#2-scope)
+- [3. Definitions/Abbreviations](#3-definitionsabbreviations)
+- [4. Overview](#4-overview)
+- [5. Requirements](#5-requirements)
+- [6. Architecture Design](#6-architecture-design)
+- [7. High-Level Design](#7-high-level-design)
+  - [7.1 Repositories and modules changed](#71-repositories-and-modules-changed)
+  - [7.2 Threading model and internal roles](#72-threading-model-and-internal-roles)
+  - [7.3 RADIUS Accounting packet contents](#73-radius-accounting-packet-contents)
+  - [7.4 Retransmit behavior](#74-retransmit-behavior)
+  - [7.5 Kernel audit consumption and reassembly](#75-kernel-audit-consumption-and-reassembly)
+  - [7.6 Per-server health and global back-pressure](#76-per-server-health-and-global-back-pressure)
+  - [7.7 Feedback-loop prevention](#77-feedback-loop-prevention)
+  - [7.8 Systemd integration](#78-systemd-integration)
+  - [7.9 Linux dependencies and interfaces](#79-linux-dependencies-and-interfaces)
+  - [7.10 Scalability and performance](#710-scalability-and-performance)
+  - [7.11 Docker and build dependencies](#711-docker-and-build-dependencies)
+  - [7.12 Serviceability and debug](#712-serviceability-and-debug)
+  - [7.13 Platform dependency](#713-platform-dependency)
+- [8. SAI API](#8-sai-api)
+- [9. Configuration and Management](#9-configuration-and-management)
+  - [9.1 Manifest](#91-manifest)
+  - [9.2 CLI/YANG model Enhancements](#92-cliyang-model-enhancements)
+  - [9.3 Config DB Enhancements](#93-config-db-enhancements)
+- [10. Warmboot and Fastboot Design Impact](#10-warmboot-and-fastboot-design-impact)
+- [11. Memory Consumption](#11-memory-consumption)
+- [12. Restrictions/Limitations](#12-restrictionslimitations)
+- [13. Testing Requirements/Design](#13-testing-requirementsdesign)
+  - [13.1 Unit Test cases](#131-unit-test-cases)
+  - [13.2 System Test cases](#132-system-test-cases)
+- [14. Open/Action items](#14-openaction-items)
+
+---
+
+## 1. Revision
+
+| Rev | Change Description                                        |
+|-----|-----------------------------------------------------------|
+| 0.1 | Initial HLD for `auditlogd` in `sonic-host-services`.     |
+
+---
+
+## 2. Scope
+
+This document describes the high-level design of `auditlogd`, a new host-level daemon in `sonic-host-services` that streams every command executed on a SONiC switch to configured RADIUS servers as an RFC 2866 **Accounting-Request**, providing operators with a central, tamper-resistant audit trail of privileged actions.
+
+**In scope**
+
+- Daemon architecture and internal roles.
+- Consumption of the existing `RADIUS_SERVER`, `MGMT_INTERFACE`, and `DEVICE_METADATA` tables in `CONFIG_DB`, including per-server `timeout` and `retransmit`.
+- RFC 2865 / 2866 conformant RADIUS Accounting-Request construction and retransmit behavior (same packet reused across retries).
+- Kernel audit consumption over `NETLINK_AUDIT`, multi-record event reassembly, and command normalization.
+- Per-server health tracking and a global back-pressure loop that pauses consumption when no RADIUS server is reachable.
+- Feedback-loop prevention against self-auditing.
+- Systemd integration under `sonic.target`.
+
+**Out of scope**
+
+- Authentication (`Access-Request`) flows — this daemon does not change how SONiC does RADIUS authentication today.
+- 802.1x / port-based authentication (PAC).
+- New CONFIG_DB tables or fields (the design deliberately reuses what exists).
+- New CLI or YANG models (a future doc will define operator-facing surfaces such as per-server health).
+- Persisting unsent events across RADIUS outages.
+
+---
+
+## 3. Definitions/Abbreviations
+
+| Term | Definition |
+|------|------------|
+| AAA | Authentication, Authorization, and Accounting |
+| RADIUS | Remote Authentication Dial In User Service (RFC 2865 / 2866) |
+| Accounting-Request | RADIUS packet code 4 used to convey session accounting information |
+| NAS | Network Access Server — the switch itself in this context |
+| NAS-Identifier | RADIUS attribute (32) identifying the NAS; set to the switch hostname |
+| Netlink audit | Kernel-to-userspace interface (`NETLINK_AUDIT`) that streams audit records |
+| `execve` | Linux syscall used to execute a program; the trigger for audit records |
+| VRF | Virtual Routing and Forwarding instance (e.g., `mgmt` VRF) |
+| CONFIG_DB | Redis DB #4 in SONiC that holds configuration state |
+
+---
+
+## 4. Overview
 
 `auditlogd` is a new daemon in `sonic-host-services` that watches every command executed on a SONiC switch and reports each one to configured RADIUS servers as an **Accounting-Request** (per RFC 2866). It gives operators a central, tamper-resistant audit trail of privileged actions on the box.
 
-The daemon is a pure consumer: it does not authenticate users, does not modify how SONiC does RADIUS auth today, and has no dependency on 802.1x/PAC. It reads:
+The daemon is a pure consumer:
+
+- It does **not** authenticate users.
+- It does **not** modify how SONiC does RADIUS auth today.
+- It has **no** dependency on 802.1x / PAC.
+
+It reads only:
 
 - Linux kernel audit events (via a netlink socket).
 - Existing RADIUS server configuration from `CONFIG_DB`.
 
 ---
 
-## 2. What Ships
+## 5. Requirements
 
-| Path                                                     | Purpose                                                             |
-|----------------------------------------------------------|---------------------------------------------------------------------|
-| `scripts/auditlogd`                                      | The daemon itself.                                                  |
-| `data/debian/sonic-host-services-data.auditlogd.service` | Systemd unit for the daemon.                                        |
-| `data/debian/rules`                                      | Registers the systemd unit at package build time.                   |
-| `setup.py`                                               | Installs the daemon as `/usr/local/bin/auditlogd`.                  |
-| `tests/auditlogd/`                                       | Unit-test suite (packet formatting, netlink, mgmt-IP, filtering).   |
+**Functional**
+
+1. Emit one RFC 2866 Accounting-Request per audited command to every configured RADIUS server.
+2. Reuse the existing SONiC RADIUS configuration (`RADIUS_SERVER`, `MGMT_INTERFACE`, `DEVICE_METADATA`) without introducing new tables.
+3. Honor per-server `timeout` (default 5 s) and `retransmit` (default 0) semantics as defined by RFC 2865 / 2866; the same packet must be reused across retries so servers can dedupe.
+4. Verify the Response Authenticator on every Accounting-Response before treating a send as successful.
+5. Track per-server health and expose transitions via logs (`disconnected` after 3 consecutive fully-failed sends; reconnect probe at most every 30 s).
+6. Pause audit consumption cleanly when no RADIUS server is reachable, so that sustained outages do not cause memory growth or block user commands.
+7. React to `RADIUS_SERVER` and management-IP changes without a manual restart.
+8. Prevent self-auditing feedback loops.
+
+**Non-functional**
+
+1. Must consume kernel audit events promptly to avoid `ENOBUFS` from the kernel.
+2. A slow or unresponsive RADIUS server must not block delivery to other servers or audit-event consumption.
+3. The daemon must run as root (required for netlink audit and audit-rule management).
+4. Restart must be capped by systemd to prevent crash-loops.
+
+**Exemptions / non-goals**
+
+- No new CLI/YANG in this phase.
+- No local persistence of unsent events (accounting is best-effort by design).
+- No changes to how SONiC currently authenticates users via RADIUS.
 
 ---
 
-## 3. Architecture
+## 6. Architecture Design
 
-`auditlogd` is a single process with two long-running threads:
-
-- **Main thread** — connects to CONFIG_DB, subscribes to the tables it cares about, and processes configuration changes as they arrive.
-- **Monitor thread** — receives audit events from the kernel, assembles them into complete records, and hands each one off to be sent as a RADIUS Accounting-Request.
-
-Internally the code is organized around four roles:
-
-| Role                       | Responsibility                                                                                                                              |
-|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| **Daemon controller**      | Process bootstrap. Owns the CONFIG_DB subscription and spawns the monitor thread.                                                            |
-| **Audit-event monitor**    | Owns the kernel audit socket. Buffers and reassembles multi-record events, applies filters, and hands each command up.                       |
-| **Audit logger**           | Loads configuration, installs kernel audit rules, and fans a command out to every configured RADIUS server.                                  |
-| **RADIUS accounting client** | Builds and sends one Accounting-Request per server, tracks per-server health, and verifies responses.                                     |
-
-RADIUS delivery for a given event runs in short-lived worker threads (one per server) so a slow server can never block audit-event consumption.
+`auditlogd` slots in as a **new host-level service** in the existing `sonic-host-services` package. It does not change the SONiC control-plane architecture: no changes to SWSS, syncd, orchagent, or SAI. It is a passive consumer of kernel state and existing CONFIG_DB tables, and a producer of RADIUS UDP traffic.
 
 ```
    kernel audit         audit-event monitor            audit logger          RADIUS accounting client        RADIUS server(s)
@@ -55,11 +148,88 @@ RADIUS delivery for a given event runs in short-lived worker threads (one per se
                                 (RADIUS_SERVER, MGMT_INTERFACE, DEVICE_METADATA)
 ```
 
+This is not a SONiC Application Extension; it is a first-party host service delivered as part of `sonic-host-services`, and does not require Application Extension infrastructure changes.
+
 ---
 
-## 4. Configuration
+## 7. High-Level Design
 
-The daemon does **not** introduce new CONFIG_DB tables or fields. It reads three existing tables:
+### 7.1 Repositories and modules changed
+
+Only `sonic-host-services` is modified — a new daemon script, its systemd unit, packaging hooks, and a unit-test folder. No changes required in `sonic-swss`, `sonic-utilities`, or `sonic-buildimage`.
+
+### 7.2 Threading model and internal roles
+
+Single process with two long-running threads: a **main thread** that owns the CONFIG_DB subscription and reacts to configuration changes, and a **monitor thread** that reads and reassembles kernel audit events. Internally the code is split into four roles — *daemon controller*, *audit-event monitor*, *audit logger*, and *RADIUS accounting client* — with per-server RADIUS delivery done on short-lived worker threads so a slow server never blocks audit-event consumption.
+
+### 7.3 RADIUS Accounting packet contents
+
+For each audited command the daemon sends one RFC 2866 Accounting-Request carrying the resolved username, `Acct-Status-Type=Start`, a unique `Acct-Session-ID`, the command line as `Called-Station-Id` (truncated to 250 bytes), the event timestamp, and the switch hostname as `NAS-Identifier`. Request and Response Authenticators are computed and verified per RFC 2866 using the shared secret.
+
+### 7.4 Retransmit behavior
+
+The per-server `timeout` (default 5 s) and `retransmit` (default 0) drive an RFC 2865 / 2866-compliant retry loop: the **same** packet — Identifier, attributes, and Request Authenticator — is reused across every attempt so servers can dedupe rather than double-count. A valid response short-circuits the loop; only fully exhausted attempts count as a failure for the per-server health state (§7.6).
+
+### 7.5 Kernel audit consumption and reassembly
+
+Events are consumed live from `NETLINK_AUDIT` (not by tailing `auditd` files), giving real-time delivery and native back-pressure signals from the kernel. At startup the daemon installs `execve` audit rules keyed `sonic_commands` and excludes its own PID; the monitor reassembles multi-record events, flushes on end-of-event markers or after a 2 s deadline, resolves the username, filters noise (audit tools and empty/degenerate commands), and hands the result to the audit logger.
+
+### 7.6 Per-server health and global back-pressure
+
+- **Per-server** — a server is marked `disconnected` after 3 consecutive fully-failed sends; reconnect is attempted at most every 30 s. Only transitions are logged at INFO.
+- **Global** — every 10 s the monitor checks whether any server is reachable. If none is, it closes the netlink socket so the kernel stops queueing events; consumption resumes when at least one server recovers. An `ENOBUFS` from the kernel forces an immediate pause.
+
+Net effect: RADIUS outages degrade cleanly with no memory growth and no impact on user commands.
+
+### 7.7 Feedback-loop prevention
+
+Three layered defenses stop the daemon from auditing itself: kernel-level PID exclusion in the audit rules, user-space filtering of `auditlogd` / `auditctl` / `ausearch` / `auditd` (including `sudo` / `python3` wrappers), and `Wants=auditd.service` (not `Requires=`) so `auditd` restarts do not cascade into `auditlogd`.
+
+### 7.8 Systemd integration
+
+Delivered as a standard `sonic-host-services` unit: ordered after `config-setup.service` and `hostcfgd.service`, bound to `sonic.target`, with a crash-loop cap of 5 restarts per 10 minutes and an `AUDITLOGD_LOG_LEVEL` environment override for verbose logging. Full unit file lives with the daemon source.
+
+### 7.9 Linux dependencies and interfaces
+
+Uses `NETLINK_AUDIT` for event ingestion, `auditctl` (once, at startup) to install audit rules, and `libaudit` / `python-audit` for record decoding. Runs in the host namespace (not a container) because it owns audit rules; the RADIUS UDP socket can optionally be bound to a VRF such as `mgmt`.
+
+### 7.10 Scalability and performance
+
+Command rates are low and per-event work is bounded by the number of configured RADIUS servers (usually a handful). The reassembly buffer is bounded by the 2 s flush deadline, and the back-pressure loop (§7.6) prevents unbounded queueing during outages.
+
+### 7.11 Docker and build dependencies
+
+No new docker container. Ships in the existing `sonic-host-services` Debian package with no additional first-party dependencies.
+
+### 7.12 Serviceability and debug
+
+Syslog logging (default `WARNING`, runtime override to `DEBUG` via the systemd environment). One INFO line per per-server disconnect/reconnect transition and per retry-recovered send. Per-server health is in-memory today and can be exposed by a future CLI/telemetry work item. Delivery is best-effort — timeouts count as failures and drive health; there is no local persistence of unsent events.
+
+### 7.13 Platform dependency
+
+Host-level Python daemon with no ASIC / SAI interaction. Runs on all supported SONiC platforms; no vendor-specific enablement is required.
+
+---
+
+## 8. SAI API
+
+Not applicable. `auditlogd` is a host-level daemon with no ASIC interaction; **no SAI APIs are used, added, or modified**.
+
+---
+
+## 9. Configuration and Management
+
+### 9.1 Manifest
+
+Not applicable — `auditlogd` is delivered as part of the built-in `sonic-host-services` package, **not** as a SONiC Application Extension. No AE manifest is required.
+
+### 9.2 CLI/YANG model Enhancements
+
+No new CLI or YANG model is introduced by this HLD.
+
+### 9.3 Config DB Enhancements
+
+**No new CONFIG_DB tables or fields are added.** The daemon reads three existing tables:
 
 - **`RADIUS_SERVER`** — one entry per server. From each entry the daemon uses:
   - the server IP (the table key),
@@ -71,138 +241,66 @@ The daemon does **not** introduce new CONFIG_DB tables or fields. It reads three
 - **`MGMT_INTERFACE`** — used to discover the management IP of `eth0`. This becomes the default source IP for any RADIUS server that does not have an explicit `src_ip`.
 - **`DEVICE_METADATA`** — the hostname of the switch (`localhost.hostname`) is used as the RADIUS `NAS-Identifier` in every accounting packet.
 
-### Reacting to configuration changes
+**Reacting to configuration changes:**
 
-| Change                          | What the daemon does                                                                            |
-|---------------------------------|-------------------------------------------------------------------------------------------------|
-| Any `RADIUS_SERVER` change      | Closes all existing RADIUS clients and re-reads the full server list.                           |
-| `eth0` management IP change     | Rebuilds only those RADIUS clients whose current source IP was the old management IP. The rebuilt client inherits the server's existing `timeout` and `retransmit` settings so behavior is unchanged across the mgmt-IP swap. |
+| Change | What the daemon does |
+|--------|----------------------|
+| Any `RADIUS_SERVER` change | Closes all existing RADIUS clients and re-reads the full server list. |
+| `eth0` management IP change | Rebuilds only those RADIUS clients whose current source IP was the old management IP. The rebuilt client inherits the server's existing `timeout` and `retransmit` settings so behavior is unchanged across the mgmt-IP swap. |
 
-No manual restart is required for either change.
-
----
-
-## 5. RADIUS Accounting
-
-For every audited command the daemon sends an Accounting-Request (packet code 4, per RFC 2866) that carries the following information:
-
-- **User-Name** — the resolved username, or `uid:<n>` if the user cannot be resolved.
-- **Acct-Status-Type** — `Start`. `Stop` / `Interim-Update` / `Accounting-On` / `Accounting-Off` are implemented for future use.
-- **Acct-Session-ID** — a unique per-command ID of the form `sonic-<epoch>-<counter>`.
-- **Called-Station-Id** — the command line itself, truncated to 250 bytes (RADIUS attribute limit is 253).
-- **Event-Timestamp** — seconds since epoch.
-- **NAS-Identifier** — the switch hostname from `DEVICE_METADATA`.
-
-The Request Authenticator is computed per RFC 2866 using the shared secret; the Response Authenticator on the reply is verified before the send is considered successful.
-
-### Timeout and retransmit
-
-Each server's `timeout` (default 5 s) is applied as the UDP socket receive timeout, and its `retransmit` (default 0) is the number of retries the daemon will attempt after the initial send. So `retransmit=2` yields up to 3 total transmissions per audit event; `retransmit=0` sends once.
-
-Retransmits follow RFC 2865 / 2866:
-
-- The **same** packet is sent on every attempt — the RADIUS Identifier, the attribute payload, and the Request Authenticator are all computed once and preserved across retries. This lets the RADIUS server correctly recognize retries as duplicates rather than distinct accounting events.
-- The daemon waits up to `timeout` seconds for a valid Accounting-Response between each attempt. A response received at any attempt short-circuits the loop and is treated as success.
-- Failures during socket setup (for example a VRF-bind error) fall through to the outer retry loop; a brief 100 ms sleep is inserted between exception retries to avoid tight loops.
-- Only if *all* attempts fail is the send counted as a failure for the per-server health state described in §7. A successful retry logs one INFO line noting how many attempts it took.
+No manual restart is required for either change. Downward compatibility is preserved because no schema keys are added, removed, or repurposed.
 
 ---
 
-## 6. Consuming Kernel Audit Events
+## 10. Warmboot and Fastboot Design Impact
 
-`auditlogd` receives audit events directly from the Linux kernel over a `NETLINK_AUDIT` multicast socket, rather than reading `auditd` log files. This gives it real-time delivery, back-pressure signals, and lets it operate even if `auditd` is briefly restarted.
-
-At startup the daemon installs two audit rules that key every `execve` syscall (on both 32-bit and 64-bit ABIs) as `sonic_commands`, and excludes its own PID to avoid self-audit. A few audit-tool executables (`auditctl`, `ausearch`, `auditd`) are keyed separately so they can be filtered out.
-
-The kernel produces multiple records per command (system-call record, exec arguments, working directory, path, process title, end-of-event marker). The monitor:
-
-1. Starts tracking an event when it sees the `sonic_commands` key on any of its records.
-2. Merges subsequent records for the same event.
-3. Flushes the reassembled event as soon as an end-of-event marker arrives (the process-title record, an explicit end-of-event record, or any record type that the kernel emits as a single-record event).
-4. Also flushes any event that has been sitting in the buffer for more than two seconds without a marker, so the buffer never leaks.
-
-When flushed, the event is filtered and normalized:
-
-- The username is resolved from the UID.
-- The command is derived preferentially from the process-title / exec-args record, joining up to the first ten arguments.
-- Empty, single-character, all-digit, hex-address-only, and audit-tool commands are discarded.
-- The daemon's own PID is filtered a second time as a safety net.
-
-Whatever survives is handed to the audit logger.
+`auditlogd` is not in the data-plane path. It has **no** warmboot or fastboot handoff requirements.
+Existing warmboot/fastboot performance targets (control-plane and data-plane downtime) are not affected.
 
 ---
 
-## 7. RADIUS Server Health & Back-Pressure
+## 11. Memory Consumption
 
-Because the daemon feeds off a kernel socket, it must consume events promptly or the kernel will start dropping (or, worse, will surface `ENOBUFS` errors). RADIUS servers are remote and can fail, so the daemon actively pauses instead of blocking:
-
-**Per-server state (tracked by the accounting client):**
-
-- A "failed send" here means all configured retransmit attempts have been exhausted for one audit event (see §5). Marked disconnected after **3 consecutive failed sends**.
-- Once disconnected, reconnect is retried at most every **30 seconds**.
-- A single log line reports each "disconnected" and "reconnected" transition; single, transient failures are only visible in DEBUG.
-
-**Global back-pressure loop (run by the monitor):**
-
-- Every **10 seconds** the monitor asks the logger whether *any* RADIUS server is currently connected or eligible for reconnect.
-- If **no** server is available, the monitor closes the netlink socket and enters a paused state. This stops userspace consumption; the kernel-side subscription is dropped, so no further events queue in the daemon's memory.
-- When at least one server is reachable again, the monitor reopens the netlink socket and resumes.
-- If the kernel ever returns `ENOBUFS` on a read, the monitor pauses immediately regardless of the 10-second cadence.
-
-The result: RADIUS outages degrade cleanly. The switch continues to operate normally; audit records that fell into the gap are dropped rather than causing memory pressure or blocking user commands.
+- When the package is not installed / the unit is masked: **zero** memory consumption.
+- When installed but disabled by configuration (no `RADIUS_SERVER` entries): the daemon runs but its monitor thread stays paused; memory is bounded by the Python interpreter footprint plus the fixed-size reassembly buffer.
+- When enabled with active traffic: memory is bounded by the reassembly buffer (per-event, flushed on end-of-event marker or after 2 s — see §7.5) plus a fixed number of short-lived worker threads (one per RADIUS server per event). No unbounded queues.
+- During sustained RADIUS outages: the global back-pressure loop (§7.6) closes the netlink socket, so incoming events do not queue in userspace memory.
 
 ---
 
-## 8. Preventing Feedback Loops
+## 12. Restrictions/Limitations
 
-Auditing the daemon that talks about auditing would blow up quickly. Three defenses:
-
-1. **Audit rules exclude the daemon's own PID at the kernel level**, so its own `execve`s are never tagged `sonic_commands`.
-2. **Any command whose executable is `auditlogd`, `auditctl`, `ausearch`, or `auditd`** is dropped in user-space filtering, including compound invocations such as `sudo auditctl ...` or `python3 auditlogd`.
-3. **`Wants=auditd.service` (not `Requires=`)**, so a restart of `auditd` does not restart `auditlogd`.
-
----
-
-## 9. Systemd Integration
-
-The daemon is installed as a normal SONiC host service:
-
-```
-[Unit]
-Description=Audit Logging daemon for command tracking and RADIUS accounting
-Wants=auditd.service
-Requires=config-setup.service
-After=auditd.service config-setup.service hostcfgd.service
-BindsTo=sonic.target
-After=sonic.target
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/auditlogd
-Restart=on-failure
-RestartSec=10
-StartLimitBurst=5
-StartLimitIntervalSec=600
-TimeoutStopSec=5
-# Environment="AUDITLOGD_LOG_LEVEL=DEBUG"    # opt-in verbose logging
-
-[Install]
-WantedBy=sonic.target
-```
-
-Notes for operators:
-
-- Ordered after `config-setup.service` and `hostcfgd.service` so CONFIG_DB is populated before the daemon starts.
-- Bound to `sonic.target`, so it starts and stops with SONiC.
-- Restart is capped at 5 restarts per 10 minutes to prevent crash-loops.
-- Default log level is `WARNING`; set `AUDITLOGD_LOG_LEVEL=DEBUG` in the service environment to enable verbose logs without touching the code.
+1. **Best-effort accounting.** RADIUS uses UDP; timeouts count as failures. During a full outage of all configured servers the monitor pauses and events in that window are dropped rather than queued. No local persistence.
+2. **Requires root privilege.** The daemon manipulates kernel audit rules and reads from `NETLINK_AUDIT`.
+3. **Command truncation.** `Called-Station-Id` (the command line) is truncated to **250 bytes** to fit under the RADIUS attribute limit of 253.
+4. **UID resolution failures** fall back to `uid:<n>` in `User-Name`.
+5. **Audit-tool commands are intentionally filtered** (`auditlogd`, `auditctl`, `ausearch`, `auditd`) to prevent feedback loops, including `sudo`/`python3` wrappers of those binaries.
+6. **No CLI/YANG surface yet.** Per-server health is in-memory only; troubleshooting today relies on `AUDITLOGD_LOG_LEVEL=DEBUG` and syslog.
+7. **No SAI or platform enablement**, and therefore no vendor-specific dependencies.
 
 ---
 
-## 10. Operational Notes
+## 13. Testing Requirements/Design
 
-- The daemon must run as root; it manipulates kernel audit rules and reads from `NETLINK_AUDIT`.
-- Accounting is best-effort. RADIUS uses UDP; timeouts are treated as failures and drive the health state described in §7. There is no local persistence of unsent events by design — sustained RADIUS outages result in a paused daemon, not unbounded memory growth.
-- To increase visibility during troubleshooting, set `AUDITLOGD_LOG_LEVEL=DEBUG` in the service environment and restart the unit.
-- Health of each RADIUS server (connected / disconnected / consecutive failures) is available in memory and can be surfaced through future CLI/telemetry work; this document does not define a CLI schema for it.
+### 13.1 Unit Test cases
 
+Delivered under `tests/auditlogd/`:
+
+- **Packet formatting** — Accounting-Request attributes and Request Authenticator match RFC 2866 for a given shared secret.
+- **Retransmit determinism** — the same packet is reused across retries and a valid response short-circuits the loop.
+- **Response validation** — a tampered Response Authenticator is rejected.
+- **Event reassembly** — multi-record kernel events are merged into one command; stale buffers flush after 2 s.
+- **Command filtering** — audit-tool commands and empty/degenerate commands are dropped.
+- **Mgmt-IP handling** — the mgmt IP of `eth0` is used as default `src_ip`, and mgmt-IP changes rebuild only affected clients while preserving `timeout` / `retransmit`.
+- **Config reactivity** — `RADIUS_SERVER` changes trigger a client rebuild without process restart.
+- **Per-server health** — a server flips to disconnected after 3 consecutive fully-failed sends and back on recovery, with one INFO log per transition.
+- **Back-pressure** — the netlink socket is closed when no server is reachable and reopened on recovery; `ENOBUFS` forces an immediate pause.
+- **Feedback-loop safety** — executing `auditctl` or `auditlogd` under audit produces no outbound Accounting-Request.
+
+### 13.2 System Test cases
+
+Regression: existing SONiC RADIUS authentication tests must continue to pass, since `auditlogd` does not modify that path.
+
+---
+
+## 14. Open/Action items

--- a/doc/radius/radius_aaa_hld.md
+++ b/doc/radius/radius_aaa_hld.md
@@ -1,210 +1,208 @@
-# High-Level Design: RADIUS Authentication & Accounting on SONiC
+# High-Level Design: `auditlogd` — RADIUS Accounting for Command Auditing
 
-**Base assumptions**: This document describes the extensions layered on top of the existing upstream RADIUS user-authentication support in SONiC (PAM + NSS via `libnss-radius`, base `RADIUS` / `RADIUS_SERVER` CONFIG_DB tables rendered by `hostcfgd`). Upstream mechanics are not re-described here.
+## 1. Overview
 
----
+`auditlogd` is a new daemon in `sonic-host-services` that watches every command executed on a SONiC switch and reports each one to configured RADIUS servers as an **Accounting-Request** (per RFC 2866). It gives operators a central, tamper-resistant audit trail of privileged actions on the box.
 
-## 1. Motivation
+The daemon is a pure consumer: it does not authenticate users, does not modify how SONiC does RADIUS auth today, and has no dependency on 802.1x/PAC. It reads:
 
-Upstream SONiC supports RADIUS-based login authentication but has three gaps that this design closes:
-
-1. **AAA vs. 802.1x server segregation** — no way to say "this RADIUS server is only for admin login, that one is only for host authentication."
-2. **VRF binding for RADIUS accounting** — RADIUS traffic on the management network requires the daemon speaking RADIUS to bind its socket into the `mgmt` VRF.
-3. **Command / audit accounting** — there is no daemon that streams a switch's audit trail (privileged commands, `auditd` records) to a central RADIUS server as Accounting-Requests.
-
-This design adds the three capabilities above while reusing all of the upstream RADIUS scaffolding for user login.
+- Linux kernel audit events (via a netlink socket).
+- Existing RADIUS server configuration from `CONFIG_DB`.
 
 ---
 
-## 2. Scope
+## 2. What Ships
 
-**In-scope (this design)**:
-
-- New per-server `usage_scope` field (`all` / `aaa_only` / `dot1x_only`) in `RADIUS_SERVER`, and its consumers in `hostcfgd` and `auditlogd`.
-- New per-server `vrf` field in `RADIUS_SERVER`, plus a global RADIUS passkey, and their consumers in the accounting path.
-- New `auditlogd` daemon in `sonic-host-services` that streams `auditd` events to RADIUS servers as Accounting-Requests.
-- `hostcfgd` extensions for AAA authentication policy (order, fail-through, local fallback) so login and accounting share coherent policy.
-
-**Out-of-scope (untouched or upstream)**:
-
-- Base RADIUS login authentication via PAM / NSS (upstream behavior, reused as-is).
-- Existing `RADIUS` global fields (`auth_type`, `passkey`, `timeout`, `retransmit`, `nas_ip`, `src_intf`) — described here only where new consumers reference them.
-- 802.1x / PAC / hostapd / `wpa_supplicant` integration.
-- TACACS+ integration.
-- TLS transport for RADIUS (RADSEC / RADIUS-over-DTLS).
+| Path                                                     | Purpose                                                             |
+|----------------------------------------------------------|---------------------------------------------------------------------|
+| `scripts/auditlogd`                                      | The daemon itself.                                                  |
+| `data/debian/sonic-host-services-data.auditlogd.service` | Systemd unit for the daemon.                                        |
+| `data/debian/rules`                                      | Registers the systemd unit at package build time.                   |
+| `setup.py`                                               | Installs the daemon as `/usr/local/bin/auditlogd`.                  |
+| `tests/auditlogd/`                                       | Unit-test suite (packet formatting, netlink, mgmt-IP, filtering).   |
 
 ---
 
-## 3. Feature Overview
+## 3. Architecture
 
-Two new consumers read the shared RADIUS configuration model and speak to the RADIUS infrastructure:
+`auditlogd` is a single process with two long-running threads:
+
+- **Main thread** — connects to CONFIG_DB, subscribes to the tables it cares about, and processes configuration changes as they arrive.
+- **Monitor thread** — receives audit events from the kernel, assembles them into complete records, and hands each one off to be sent as a RADIUS Accounting-Request.
+
+Internally the code is organized around four roles:
+
+| Role                       | Responsibility                                                                                                                              |
+|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| **Daemon controller**      | Process bootstrap. Owns the CONFIG_DB subscription and spawns the monitor thread.                                                            |
+| **Audit-event monitor**    | Owns the kernel audit socket. Buffers and reassembles multi-record events, applies filters, and hands each command up.                       |
+| **Audit logger**           | Loads configuration, installs kernel audit rules, and fans a command out to every configured RADIUS server.                                  |
+| **RADIUS accounting client** | Builds and sends one Accounting-Request per server, tracks per-server health, and verifies responses.                                     |
+
+RADIUS delivery for a given event runs in short-lived worker threads (one per server) so a slow server can never block audit-event consumption.
 
 ```
-                        +---------------------------+
-   SSH / console  --->  |  hostcfgd renders PAM/NSS |  <---> RADIUS server(s)  (Auth)
-   (admin login)        |  filtered by usage_scope  |        usage_scope in {all, aaa_only}
-                        +---------------------------+
+   kernel audit         audit-event monitor            audit logger          RADIUS accounting client        RADIUS server(s)
+   (execve rules)  --netlink-->  reassemble  --command-->   fan-out  --thread-per-server-->  UDP  ------->
 
-                        +---------------------------+
-   audit events  --->   |  auditlogd (new daemon)   |  <---> RADIUS server(s)  (Acct)
-   (auditd -> netlink)  |  RADIUS Accounting client |        usage_scope in {all, aaa_only}
-                        +---------------------------+
-
-                Configuration source: CONFIG_DB::RADIUS + RADIUS_SERVER
-                (existing tables, extended with `usage_scope` and `vrf`)
+                                        ^
+                                        | reload / update
+                                        |
+                           daemon controller (main thread)
+                                        ^
+                                        |
+                                     CONFIG_DB
+                                (RADIUS_SERVER, MGMT_INTERFACE, DEVICE_METADATA)
 ```
-
-`hostcfgd` is the sole renderer of RADIUS-related on-disk configuration. `auditlogd` is a new systemd service supplied by `sonic-host-services-data`.
 
 ---
 
-## 4. Data Model (CONFIG_DB) — Additions Only
+## 4. Configuration
 
-Only the newly added fields are documented here. The existing `RADIUS` and `RADIUS_SERVER` schemas remain as upstream.
+The daemon does **not** introduce new CONFIG_DB tables or fields. It reads three existing tables:
 
-### 4.1 `RADIUS` (global) — new consumers of the existing `passkey`
+- **`RADIUS_SERVER`** — one entry per server. From each entry the daemon uses:
+  - the server IP (the table key),
+  - the accounting port (falls back to the auth port, then to 1813),
+  - the shared secret (`passkey`),
+  - an optional explicit source IP (`src_ip`),
+  - the request `timeout` in seconds (defaults to 5),
+  - the number of `retransmit` retries (defaults to 0 — send once, no retry).
+- **`MGMT_INTERFACE`** — used to discover the management IP of `eth0`. This becomes the default source IP for any RADIUS server that does not have an explicit `src_ip`.
+- **`DEVICE_METADATA`** — the hostname of the switch (`localhost.hostname`) is used as the RADIUS `NAS-Identifier` in every accounting packet.
 
-The upstream global `passkey` is now also consumed by `auditlogd` as the RADIUS shared secret when a server has not defined its own per-server passkey.
+### Reacting to configuration changes
 
-### 4.2 `RADIUS_SERVER|<host>` — new fields
+| Change                          | What the daemon does                                                                            |
+|---------------------------------|-------------------------------------------------------------------------------------------------|
+| Any `RADIUS_SERVER` change      | Closes all existing RADIUS clients and re-reads the full server list.                           |
+| `eth0` management IP change     | Rebuilds only those RADIUS clients whose current source IP was the old management IP. The rebuilt client inherits the server's existing `timeout` and `retransmit` settings so behavior is unchanged across the mgmt-IP swap. |
 
-| Field           | Type   | Notes                                                                                                                            |
-|-----------------|--------|----------------------------------------------------------------------------------------------------------------------------------|
-| **`vrf`**       | string | VRF name (typically `mgmt`) that RADIUS traffic is sourced from. Consumed by `auditlogd` to bind its accounting socket.          |
-| **`usage_scope`** | enum | `all` / `aaa_only` / `dot1x_only`. Selects which subsystem(s) may use this server. Consumed by both `hostcfgd` and `auditlogd`. |
-
-`usage_scope` semantics used by this design:
-
-- Login AAA (via `hostcfgd`-rendered PAM/NSS) uses servers with `all` or `aaa_only`.
-- Accounting (`auditlogd`) uses servers with `all` or `aaa_only` — dot1x-only servers are excluded so that administrator command audit trails are never sent to end-host RADIUS servers.
-- `dot1x_only` servers are ignored by both consumers described in this design.
-
-The upstream per-server `timeout` and `retransmit` fields, previously used only by the PAM login path, are now also honored by `auditlogd` (see §5.2).
-
----
-
-## 5. Component Design
-
-### 5.1 `hostcfgd` extensions
-
-`hostcfgd` already renders `/etc/pam.d/*` and `/etc/nsswitch.conf` from `RADIUS` / `RADIUS_SERVER`. This design adds three new behaviors:
-
-- **`usage_scope`-aware rendering** — when rendering the login (PAM/NSS) configuration, `hostcfgd` filters `RADIUS_SERVER` entries to those with `usage_scope ∈ {all, aaa_only}`.
-- **VRF normalization** — when a server declares a `vrf`, that value is surfaced to downstream consumers (`auditlogd`) via the shared configuration surface.
-- **AAA authentication policy** — a new authentication-policy configuration (order, fail-through, local fallback) is honored so that both the login path and `auditlogd` operate under coherent, explicit policy rather than implicit defaults.
-
-### 5.2 `auditlogd` — new RADIUS Accounting daemon
-
-`auditlogd` is a new daemon shipped by `sonic-host-services-data`. It subscribes to Linux `auditd` events over netlink, formats each event as a RADIUS Accounting-Request, and sends it to every enabled RADIUS server.
-
-```
-    auditd  --(netlink AUDIT)-->  auditlogd  --(RADIUS Acct-Request UDP)-->  radius_server
-                                     |
-                                     +-- reads RADIUS / RADIUS_SERVER from CONFIG_DB
-                                     +-- filters by usage_scope in {all, aaa_only}
-                                     +-- binds socket to `vrf` (e.g. mgmt)
-                                     +-- retransmit / timeout / throttling
-                                     +-- STATE_DB status
-```
-
-Packaging:
-
-- A systemd unit `auditlogd.service` shipped by `sonic-host-services-data`.
-- A Python daemon (`scripts/auditlogd`) with an internal `RadiusAccountingClient`.
-- A pytest suite covering netlink handling, RADIUS packet formatting, mgmt-IP / patterns, throttle behavior, and VRF/passkey behavior.
-
-Behaviors introduced by this design:
-
-- **`usage_scope` filter** — an accounting log fans out only to servers with `usage_scope ∈ {all, aaa_only}`. Prevents administrator audit records from being sent to dot1x-only servers.
-- **VRF binding + global passkey** — the RADIUS accounting socket is bound to the server's `vrf`; the global `RADIUS|global` `passkey` is used unless the server defines its own. A consecutive-failure threshold avoids false-positive server-down declarations.
-- **RFC-correct retransmit** — retries reuse the **same** RADIUS Identifier and packet contents, waiting `timeout` seconds between attempts (e.g. `retransmit=2` produces 3 total sends). Per-server `timeout` and `retransmit` from CONFIG_DB are honored; settings are preserved across management-IP updates.
-- **Log throttling** — de-duplicates and rate-limits repeat WARN/ERR log lines (e.g. "Failed to send audit log to RADIUS server X (N consecutive failures)", "Failed to bind to VRF mgmt: [Errno 19]…") so syslog does not flood under sustained failures.
+No manual restart is required for either change.
 
 ---
 
-## 6. Configuration Example
+## 5. RADIUS Accounting
 
-Only the fields relevant to this design are shown; the rest of the base RADIUS configuration is unchanged from upstream.
+For every audited command the daemon sends an Accounting-Request (packet code 4, per RFC 2866) that carries the following information:
 
-```json
-{
-  "RADIUS": {
-    "global": {
-      "passkey": "sonic-shared-secret",
-      "timeout": "5",
-      "retransmit": "2"
-    }
-  },
-  "RADIUS_SERVER": {
-    "10.29.157.71": {
-      "auth_port": "1812",
-      "acct_port": "1813",
-      "priority": "1",
-      "vrf": "mgmt",
-      "usage_scope": "aaa_only",
-      "timeout": "10",
-      "retransmit": "2"
-    },
-    "10.29.157.72": {
-      "auth_port": "1812",
-      "acct_port": "1813",
-      "priority": "2",
-      "vrf": "mgmt",
-      "usage_scope": "dot1x_only"
-    }
-  }
-}
-```
+- **User-Name** — the resolved username, or `uid:<n>` if the user cannot be resolved.
+- **Acct-Status-Type** — `Start`. `Stop` / `Interim-Update` / `Accounting-On` / `Accounting-Off` are implemented for future use.
+- **Acct-Session-ID** — a unique per-command ID of the form `sonic-<epoch>-<counter>`.
+- **Called-Station-Id** — the command line itself, truncated to 250 bytes (RADIUS attribute limit is 253).
+- **Event-Timestamp** — seconds since epoch.
+- **NAS-Identifier** — the switch hostname from `DEVICE_METADATA`.
 
-In this configuration, `auditlogd` will send Accounting-Requests only to `10.29.157.71`, binding the socket into VRF `mgmt`, using the global passkey, with a 10-second timeout and two retransmits per event.
+The Request Authenticator is computed per RFC 2866 using the shared secret; the Response Authenticator on the reply is verified before the send is considered successful.
+
+### Timeout and retransmit
+
+Each server's `timeout` (default 5 s) is applied as the UDP socket receive timeout, and its `retransmit` (default 0) is the number of retries the daemon will attempt after the initial send. So `retransmit=2` yields up to 3 total transmissions per audit event; `retransmit=0` sends once.
+
+Retransmits follow RFC 2865 / 2866:
+
+- The **same** packet is sent on every attempt — the RADIUS Identifier, the attribute payload, and the Request Authenticator are all computed once and preserved across retries. This lets the RADIUS server correctly recognize retries as duplicates rather than distinct accounting events.
+- The daemon waits up to `timeout` seconds for a valid Accounting-Response between each attempt. A response received at any attempt short-circuits the loop and is treated as success.
+- Failures during socket setup (for example a VRF-bind error) fall through to the outer retry loop; a brief 100 ms sleep is inserted between exception retries to avoid tight loops.
+- Only if *all* attempts fail is the send counted as a failure for the per-server health state described in §7. A successful retry logs one INFO line noting how many attempts it took.
 
 ---
 
-## 7. Sequence Diagram — Command Audit via `auditlogd`
+## 6. Consuming Kernel Audit Events
 
-An operator logs into SONiC via SSH (authenticated by the upstream PAM/NSS RADIUS machinery, which `hostcfgd` renders with `usage_scope` filtering), executes a privileged command, and has that command streamed as a RADIUS Accounting-Request by `auditlogd`.
+`auditlogd` receives audit events directly from the Linux kernel over a `NETLINK_AUDIT` multicast socket, rather than reading `auditd` log files. This gives it real-time delivery, back-pressure signals, and lets it operate even if `auditd` is briefly restarted.
 
-```mermaid
-sequenceDiagram
-    autonumber
-    actor Admin
-    participant SSHD as sshd (+ PAM/NSS)
-    participant HC as hostcfgd
-    participant CDB as CONFIG_DB<br/>(RADIUS / RADIUS_SERVER)
-    participant AUD as auditd
-    participant ALD as auditlogd
-    participant AAAS as RADIUS server<br/>(usage_scope: aaa_only)
-    participant STDB as STATE_DB
+At startup the daemon installs two audit rules that key every `execve` syscall (on both 32-bit and 64-bit ABIs) as `sonic_commands`, and excludes its own PID to avoid self-audit. A few audit-tool executables (`auditctl`, `ausearch`, `auditd`) are keyed separately so they can be filtered out.
 
-    Note over HC,CDB: On boot and on any RADIUS config change
-    HC->>CDB: subscribe(RADIUS, RADIUS_SERVER)
-    CDB-->>HC: config snapshot
-    HC->>SSHD: render PAM / NSS<br/>(only usage_scope in {all, aaa_only})
-    HC->>ALD: expose auditlogd config<br/>(aaa-only servers, vrf, passkey, timeout/retransmit)
+The kernel produces multiple records per command (system-call record, exec arguments, working directory, path, process title, end-of-event marker). The monitor:
 
-    Admin->>SSHD: SSH login
-    SSHD->>AAAS: (upstream PAM/NSS) RADIUS Access-Request via VRF=mgmt
-    AAAS-->>SSHD: Access-Accept
-    SSHD-->>Admin: shell
+1. Starts tracking an event when it sees the `sonic_commands` key on any of its records.
+2. Merges subsequent records for the same event.
+3. Flushes the reassembled event as soon as an end-of-event marker arrives (the process-title record, an explicit end-of-event record, or any record type that the kernel emits as a single-record event).
+4. Also flushes any event that has been sitting in the buffer for more than two seconds without a marker, so the buffer never leaks.
 
-    Note over Admin,ALD: Admin runs a privileged command
-    Admin->>SSHD: sudo config vlan add 100
-    SSHD->>AUD: audit record (uid, cmd, exit)
-    AUD-->>ALD: netlink AUDIT event
+When flushed, the event is filtered and normalized:
 
-    ALD->>CDB: read RADIUS + RADIUS_SERVER (cached)
-    Note right of ALD: filter servers where<br/>usage_scope in {all, aaa_only}
-    ALD->>AAAS: Accounting-Request<br/>(Acct-Status-Type=Start/Interim/Stop,<br/>User-Name, NAS-Port-Id, ...)<br/>bound to VRF=mgmt
+- The username is resolved from the UID.
+- The command is derived preferentially from the process-title / exec-args record, joining up to the first ten arguments.
+- Empty, single-character, all-digit, hex-address-only, and audit-tool commands are discarded.
+- The daemon's own PID is filtered a second time as a safety net.
 
-    alt Ack received
-        AAAS-->>ALD: Accounting-Response
-        ALD->>STDB: update auditlogd state (last_ok, counters)
-    else No response within timeout
-        loop retransmit N times (same Identifier)
-            ALD->>AAAS: Accounting-Request (retry)
-        end
-        ALD->>STDB: increment consecutive_failures
-        Note over ALD: throttle repeated<br/>WARN/ERR log lines
-    end
+Whatever survives is handed to the audit logger.
+
+---
+
+## 7. RADIUS Server Health & Back-Pressure
+
+Because the daemon feeds off a kernel socket, it must consume events promptly or the kernel will start dropping (or, worse, will surface `ENOBUFS` errors). RADIUS servers are remote and can fail, so the daemon actively pauses instead of blocking:
+
+**Per-server state (tracked by the accounting client):**
+
+- A "failed send" here means all configured retransmit attempts have been exhausted for one audit event (see §5). Marked disconnected after **3 consecutive failed sends**.
+- Once disconnected, reconnect is retried at most every **30 seconds**.
+- A single log line reports each "disconnected" and "reconnected" transition; single, transient failures are only visible in DEBUG.
+
+**Global back-pressure loop (run by the monitor):**
+
+- Every **10 seconds** the monitor asks the logger whether *any* RADIUS server is currently connected or eligible for reconnect.
+- If **no** server is available, the monitor closes the netlink socket and enters a paused state. This stops userspace consumption; the kernel-side subscription is dropped, so no further events queue in the daemon's memory.
+- When at least one server is reachable again, the monitor reopens the netlink socket and resumes.
+- If the kernel ever returns `ENOBUFS` on a read, the monitor pauses immediately regardless of the 10-second cadence.
+
+The result: RADIUS outages degrade cleanly. The switch continues to operate normally; audit records that fell into the gap are dropped rather than causing memory pressure or blocking user commands.
+
+---
+
+## 8. Preventing Feedback Loops
+
+Auditing the daemon that talks about auditing would blow up quickly. Three defenses:
+
+1. **Audit rules exclude the daemon's own PID at the kernel level**, so its own `execve`s are never tagged `sonic_commands`.
+2. **Any command whose executable is `auditlogd`, `auditctl`, `ausearch`, or `auditd`** is dropped in user-space filtering, including compound invocations such as `sudo auditctl ...` or `python3 auditlogd`.
+3. **`Wants=auditd.service` (not `Requires=`)**, so a restart of `auditd` does not restart `auditlogd`.
+
+---
+
+## 9. Systemd Integration
+
+The daemon is installed as a normal SONiC host service:
+
 ```
+[Unit]
+Description=Audit Logging daemon for command tracking and RADIUS accounting
+Wants=auditd.service
+Requires=config-setup.service
+After=auditd.service config-setup.service hostcfgd.service
+BindsTo=sonic.target
+After=sonic.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/auditlogd
+Restart=on-failure
+RestartSec=10
+StartLimitBurst=5
+StartLimitIntervalSec=600
+TimeoutStopSec=5
+# Environment="AUDITLOGD_LOG_LEVEL=DEBUG"    # opt-in verbose logging
+
+[Install]
+WantedBy=sonic.target
+```
+
+Notes for operators:
+
+- Ordered after `config-setup.service` and `hostcfgd.service` so CONFIG_DB is populated before the daemon starts.
+- Bound to `sonic.target`, so it starts and stops with SONiC.
+- Restart is capped at 5 restarts per 10 minutes to prevent crash-loops.
+- Default log level is `WARNING`; set `AUDITLOGD_LOG_LEVEL=DEBUG` in the service environment to enable verbose logs without touching the code.
+
+---
+
+## 10. Operational Notes
+
+- The daemon must run as root; it manipulates kernel audit rules and reads from `NETLINK_AUDIT`.
+- Accounting is best-effort. RADIUS uses UDP; timeouts are treated as failures and drive the health state described in §7. There is no local persistence of unsent events by design — sustained RADIUS outages result in a paused daemon, not unbounded memory growth.
+- To increase visibility during troubleshooting, set `AUDITLOGD_LOG_LEVEL=DEBUG` in the service environment and restart the unit.
+- Health of each RADIUS server (connected / disconnected / consecutive failures) is available in memory and can be surfaced through future CLI/telemetry work; this document does not define a CLI schema for it.
 


### PR DESCRIPTION
## Summary

- Adds a SONiC HLD for **`auditlogd`**, a new `sonic-host-services` daemon that streams every command executed on the switch to configured RADIUS servers as RFC 2866 Accounting-Requests, providing a central, tamper-resistant audit trail of privileged actions.
- Covers daemon architecture and threading model (main thread + monitor thread, with per-server worker threads for RADIUS delivery), the four internal roles (daemon controller, audit-event monitor, audit logger, RADIUS accounting client), consumption of the existing `RADIUS_SERVER` / `MGMT_INTERFACE` / `DEVICE_METADATA` tables (including per-server `timeout` and `retransmit`), RFC 2865 / 2866 retransmit behavior (same packet reused across retries so servers can dedupe), `NETLINK_AUDIT` consumption with multi-record event reassembly, per-server health tracking with a global back-pressure loop that pauses consumption when no RADIUS server is reachable, feedback-loop prevention (kernel-level PID exclusion plus user-space filtering of audit tooling), and systemd integration.


## Motivation

SONiC currently has no built-in way to produce a centralized, RADIUS-based audit trail of privileged commands executed on a switch. `auditlogd` fills that gap by consuming kernel audit events over `NETLINK_AUDIT` and emitting one RFC 2866 Accounting-Request per command to the RADIUS servers already configured in `CONFIG_DB`. The daemon is a pure consumer: it does not authenticate users, does not change how SONiC does RADIUS auth today, has no dependency on 802.1x/PAC, and introduces no new CONFIG_DB tables or fields. Accounting is best-effort by design — during sustained RADIUS outages the daemon pauses cleanly rather than growing memory or blocking user commands.

## Test plan

- [ ] Documentation review by SONiC community / security WG
- [ ] Unit tests under `tests/auditlogd/`
- [ ] Follow-up implementation PRs in `sonic-host-services` per this HLD

## Related work
