### PR TITLE
maintainer nomination: Brad House

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -68,6 +68,7 @@
 |  | Yilan Ji (Google) | baxia-lan | enabled |
 |  | Praveen Elagala (BRCM) | Praveen-Brcm | Approved on 5/3/2023 and enabled |
 |  | Prasanth Veettil (BRCM) | Prasanth-KV | Approved on 5/3/2023 and enabled |
+|  | Brad House (Nexthop) | bhouse-nexthop | Request on 7/13/2026 |
 | sonic-mgmt | Ying Xie (Microsoft) | yxieca | enabled |
 |  | Xin Wang (Microsoft) | wangxin | enabled |
 |  | Bhavani Parise (Cisco) | bpar9 | enabled |


### PR DESCRIPTION
Company: Nexthop Systems Inc
Github ID: bhouse-nexthop
Target Repository: sonic-buildimage

Justification:

Brad House is a software engineer at Nexthop AI working on SONiC infrastructure, automation, build/release tooling, and security. He has been contributing to SONiC for about 2 years.

Outside of SONiC, Brad brings 20+ years of open-source experience as a long-time community leader:

   - Maintainer & principal developer of c-ares (2017–present), the asynchronous DNS resolver library with over 1 billion installations, embedded in Node.js, cURL, gRPC, and many other widely deployed projects.
   - Former lead developer for the amd64 architecture in Gentoo Linux, architecting the initial transition from 32-bit to 64-bit systems.
   - CISSP-certified, with a background as CIO/CISO of a PCI P2PE-validated FinTech platform.

Guohan Lu and Ying Xie of Microsoft have advised Brad to apply for maintainership of sonic-buildimage, where he has been one of the most active community contributors over the past two years.

SONiC contribution summary:

   - Greater than 75 merged PRs and 150 PRs reviewed/commented on across the sonic-net org.
   - libyang1 → libyang3 migration: leading the in-flight multi-repo upgrad across sonic-buildimage, sonic-yang-mgmt, sonic-swss-common, sonic-mgmt-common, and most downstream repos.
   - Secureboot: a series of production-hardening PRs covering signing, ephemeral keys, and kernel module verification.
   - YANG models & sonic-yang-mgmt: numerous additions and correctness fixes (BGP autort, l2vpn EVPN, route-map / prefix-set, ZTP, DNS/SSH hardening, COPP exclusions) plus GCU performance work.
   - VXLAN EVPN: bug fixes and feature work in orchagent, neighsync, vxlanorch, and frr-mgmt-framework.
   - Build & test infrastructure improvements.

Community involvement:

   - Founder and Chair of the new Public SONiC Security Working Group
   - Co-hosting the sonic-mgmt issues triage meeting in July 2026, with additional sessions planned, and is currently working with the maintainers to take on the same role for the sonic-buildimage issues triage meetings.

Granting Brad commit access to sonic-buildimage would let him take on a larger share of PR review and merge work for community contributions, reducing load on the existing maintainers and improving turnaround for outside contributors.