### PR TITLE
Add Team column to SONiC Repo Maintainer list

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -1,90 +1,84 @@
 # SONiC Repo Maintainer List
 
-| Repo | Maintainer | Github Id | Comments |
-|---|---|---|---|
-| sonic-ztp | Rajendra Dendukuri (Broadcom) | rajendra-dendukuri | enabled |
-| sonic-stp | Divya Chandralekha (Broadcom) | divyachandralekha | enabled |
-| sonic-dbsyncd | Storm Liang (Microsoft） | StormLiangMS | enabled |
-| sonic-dhcp-relay | Kelly Yeh (Microsoft) | kellyyeh | enabled |
-|  | Saikrishna Arcot (Microsoft) | saiarcot895 | enabled |
-|  | Propose add Jie Cai (Microsoft) - Nominated by Ying Xie | jcaiMR | enabled |
-|  | Ying Xie (Microsoft) | yxieca | enabled |
-| sonic-bmp | Syed Hasan Raza Naqvi (BRCM) | hasan-brcm | enabled |
-|  | Prince Sunny (Microsoft) | prsunny | enabled |
-|  | Sudharsan Dhamal Gopalarathnam (Nvidia) | dgsudharsan | enabled |
-|  | R, Gokulnath(DELL) reviewer | Gokulnath-Raja | enabled |
-| sonic-linkmgrd | Jing Zhang (Microsoft) | zjswhhh | enabled |
-|  | Longxiang Lyu (Microsoft) | lolyu | enabled |
-|  | Ying Xie (Microsoft) | yxieca | enabled |
-| sonic-linux-kernel | Saikrishna Arcot (Microsoft) | saiarcot895 | enabled |
-| sonic-mgmt-common | Kim, Kwan (DELL) | kwangsuk | enabled |
-|  | Shashank Neelam (Google) | sneelam20 | enabled |
-|  | Anand Subramanian (BRCM) | anand-kumar-subramanian | enabled |
-| sonic-mgmt-framework | Joseph, Joyas (DELL) | joyas-joseph | enabled |
-|  | Shashank Neelam | sneelam20 | Replace Tomek on 3/5/2024 |
-|  | Anand Subramanian (BRCM) | anand-kumar-subramanian | Approved on 5/3/2023 and enabled |
-| sonic-pins | Bhagatram Janarthanan (Google) | bhagatgit | enabled |
-|  | Brian O'Connor (Google) | bocon13 | invitation sent |
-|  | Ravi Vantipalli (Intel) | ravi861 | enabled |
-|  | Kishan (Google) | kishanps | enabled |
-| sonic-platform-common | Prince George (Microsoft) | prgeor | enabled |
-|  | Mridul Bajpai (Cisco) | bmridul | enabled |
-|  | Kebo Liu (Nvidia) | keboliu | enabled |
-| sonic-platform-daemons | Prince George (Microsoft) | prgeor | enabled |
-|  | Mridul Bajpai (Cisco) | bmridul | enabled |
-|  | Kebo Liu (Nvidia) | keboliu | enabled |
-| sonic-platform-pdk-pde | Geans Pin (BRCM) | geans-pin | enabled |
-| sonic-py-swsssdk | Hua Liu (Microsoft) | liuh-80 | enabled |
-| sonic-restapi | Lawrence Lee (Microsoft) | theasianpianist | enabled |
-| sonic-sairedis | Kamil Cudnik (Microsoft) | kcudnik | added |
-|  | Junhua Zhai (Microsoft) | jimmyzhai | added |
-|  | Andriy Kokhan (Intel) | akokhan | enabled |
-|  | Volodymyr Boiko (Intel) | vboykox | enabled |
-|  | Kishore Gummadidala(Google) | erohsik | invitation sent |
-|  | Vishnu Shetty | vishnushetty | enabled |
-| sonic-snmpagent | Suvarna Meenakshi (Microsoft) | SuvarnaMeenakshi | enabled |
-| sonic-swss | Guohan Lu (Microsoft) | lguohan | added |
-|  | Prince Sunny (Microsoft) | prsunny | added |
-|  | Marian Pritsak (Nvidia) | marian-pritsak | added |
-|  | Stephen Wang(Google) | StephenWangGoogle | enabled |
-|  | Laveen Thamilchelvam (BRCM) | LaveenBrcm | Approved on 5/3/2023 and enabled |
-|  | Rajesh Sankaran (BRCM) | srj102 | Approved on 5/3/2023 and enabled |
-| sonic-swss-common | Qi Luo (Microsoft) | qiluo-msft | eanbled |
-|  | Hua Liu (Microsoft) | liuh-80 | enabled |
-|  | Myron Sosyak (Intel) | msosyak | enabled |
-|  | Marian Pritsak (Nvidia) | marian-pritsak | enabled |
-|  | Runming Wu(Google) | mint570 | enabled |
-| sonic-gnmi (previously sonic-telemetry) | Qi Luo (Microsoft) | qiluo-msft | enabled |
-|  | Shashank Neelam | sneelam20 | Replace Tomek on 3/5/2024 |
-|  | Shishao (Alibaba) | shishao7sxm | invitation sent |
-|  | Seifert, Eric (DELL) | seiferteric | enabled |
-|  | Anand Subramanian (BRCM) | anand-kumar-subramanian | Approved on 5/3/2023 and enabled |
-| sonic-utilities | Qi Luo (Microsoft) | qiluo-msft | enabled |
-| sonic-wpa-supplicant | Ze Gan (Microsoft) | Pterosaur | enabled |
-| sonic-buildimage | Guohan Lu (Microsoft) | lguohan | enabled |
-|  | Ying Xie (Microsoft) | yxieca | enabled |
-|  | Kumaresh Perumal (Microsoft) | kperumalbfn | enabled |
-|  | Don Newton (Intel) | donNewtonIntel | enabled |
-|  | Yilan Ji (Google) | baxia-lan | enabled |
-|  | Praveen Elagala (BRCM) | Praveen-Brcm | Approved on 5/3/2023 and enabled |
-|  | Prasanth Veettil (BRCM) | Prasanth-KV | Approved on 5/3/2023 and enabled |
-| sonic-mgmt | Ying Xie (Microsoft) | yxieca | enabled |
-|  | Xin Wang (Microsoft) | wangxin | enabled |
-|  | Bhavani Parise (Cisco) | bpar9 | enabled |
-|  | John Cheung (Intel) | johcheun | invitation sent |
-|  | Myron Sosyak (Intel) | msosyak | enabled |
-|  | Vamsi Punati(Google) | vamsipunati | invitation sent |
-|  | Sasthri Kristipati (BRCM) | ramakristipati | Approved on 5/3/2023 and enabled |
-| sonic-fips | Xuhui Miao (Microsoft) | xumia | enabled |
-| sonic-genl-packet | Don Newton (Intel) | donNewtonIntel | enabled |
-| sonic-platform-vpp | Abdel Baig; Yue Gao (yuega2) | yue-fred-gaoabdbaig | enabled |
-|  | Bendrapu Balareddy (Cisco) | bendrapubalareddy | invitation sent |
-|  | Venkatesan Mahalingam (Dell) | venkatmahalingam | enabled |
-| sonic-dash-api | Ze Gan (Microsoft) | Pterosaur | enabled |
-| sonic-dash-ha | Riff Jiang (Microsoft) | r12f |  |
-| sonic-bmp | Feng Pan (Microsoft) | FengPan-Frank |  |
-|  | Qi Luo(Microsoft) | qiluo-msft | enabled |
-| sonic-host-services | Qi Luo(Microsoft) | qiluo-msft |  |
-| sonic-formal-infra | Mengqi Liu (Alibaba) | mengqiliu20 | enabled |
-|  | Ali Kheradmand (Google) | kheradmandG |enabled  |
-| sonic-redfish |  |  |  |
+| Repo | Team | Maintainer | Github Id | Comments |
+|---|---|---|---|---|
+| sonic-ztp | sonic-ztp-maintainer | Rajendra Dendukuri (Broadcom) | rajendra-dendukuri | enabled |
+| sonic-stp | sonic-stp-maintainer | Divya Chandralekha (Broadcom) | divyachandralekha | enabled |
+| sonic-dbsyncd | sonic-dbsyncd-maintainer | Storm Liang (Microsoft） | StormLiangMS | enabled |
+| sonic-dhcp-relay | sonic-dhcp-relay-maintainer | Saikrishna Arcot (Microsoft) | saiarcot895 | enabled |
+|  | sonic-dhcp-relay-maintainer | Ying Xie (Microsoft) | yxieca | enabled |
+| sonic-bmp | sonic-bmp-maintainer | Syed Hasan Raza Naqvi (BRCM) | hasan-brcm | enabled |
+|  | sonic-bmp-maintainer | Prince Sunny (Microsoft) | prsunny | enabled |
+|  | sonic-bmp-maintainer | Sudharsan Dhamal Gopalarathnam (Nvidia) | dgsudharsan | enabled |
+|  | sonic-bmp-maintainer | R, Gokulnath(DELL) reviewer | Gokulnath-Raja | enabled |
+| sonic-linkmgrd | sonic-linkmgrd-maintainer | Jing Zhang (Microsoft) | zjswhhh | enabled |
+|  | sonic-linkmgrd-maintainer | Longxiang Lyu (Microsoft) | lolyu | enabled |
+|  | sonic-linkmgrd-maintainer | Ying Xie (Microsoft) | yxieca | enabled |
+| sonic-linux-kernel | sonic-linux-kernel-maintainer | Saikrishna Arcot (Microsoft) | saiarcot895 | enabled |
+| sonic-mgmt-common | sonic-mgmt-common-maintainer | Kim, Kwan (DELL) | kwangsuk | enabled |
+|  | sonic-mgmt-common-maintainer | Shashank Neelam (Google) | sneelam20 | enabled |
+|  | sonic-mgmt-common-maintainer | Anand Subramanian (BRCM) | anand-kumar-subramanian | enabled |
+| sonic-mgmt-framework | sonic-mgmt-framework-maintainer | Joseph, Joyas (DELL) | joyas-joseph | enabled |
+|  | sonic-mgmt-framework-maintainer | Shashank Neelam | sneelam20 | Replace Tomek on 3/5/2024 |
+|  | sonic-mgmt-framework-maintainer | Anand Subramanian (BRCM) | anand-kumar-subramanian | Approved on 5/3/2023 and enabled |
+| sonic-pins | sonic-pins-maintainer | Bhagatram Janarthanan (Google) | bhagatgit | enabled |
+|  | sonic-pins-maintainer | Brian O'Connor (Google) | bocon13 | invitation sent |
+|  | sonic-pins-maintainer | Ravi Vantipalli (Intel) | ravi861 | enabled |
+|  | sonic-pins-maintainer | Kishan (Google) | kishanps | enabled |
+| sonic-platform-common | sonic-platform-common-maintainer | Prince George (Microsoft) | prgeor | enabled |
+|  | sonic-platform-common-maintainer | Mridul Bajpai (Cisco) | bmridul | enabled |
+|  | sonic-platform-common-maintainer | Kebo Liu (Nvidia) | keboliu | enabled |
+| sonic-platform-daemons | sonic-platform-daemons-maintainer | Prince George (Microsoft) | prgeor | enabled |
+|  | sonic-platform-daemons-maintainer | Mridul Bajpai (Cisco) | bmridul | enabled |
+|  | sonic-platform-daemons-maintainer | Kebo Liu (Nvidia) | keboliu | enabled |
+| sonic-platform-pdk-pde | sonic-platform-pdk-pde-maintainer | Geans Pin (BRCM) | geans-pin | enabled |
+| sonic-py-swsssdk | sonic-py-swsssdk-maintainer | Prince Sunny (Microsoft) | prsunny | enabled |
+| sonic-restapi | sonic-restapi-maintainer | Lawrence Lee (Microsoft) | theasianpianist | enabled |
+| sonic-sairedis | sonic-sairedis-maintainer | Kamil Cudnik (Microsoft) | kcudnik | added |
+|  | sonic-sairedis-maintainer | Junhua Zhai (Microsoft) | jimmyzhai | added |
+|  | sonic-sairedis-maintainer | Andriy Kokhan (Intel) | akokhan | enabled |
+|  | sonic-sairedis-maintainer | Volodymyr Boiko (Intel) | vboykox | enabled |
+|  | sonic-sairedis-maintainer | Kishore Gummadidala(Google) | erohsik | invitation sent |
+|  | sonic-sairedis-maintainer | Vishnu Shetty | vishnushetty | enabled |
+| sonic-snmpagent | sonic-snmpagent-maintainer | Suvarna Meenakshi (Microsoft) | SuvarnaMeenakshi | enabled |
+| sonic-swss | sonic-swss-maintainer | Guohan Lu (Microsoft) | lguohan | added |
+|  | sonic-swss-maintainer | Prince Sunny (Microsoft) | prsunny | added |
+|  | sonic-swss-maintainer | Marian Pritsak (Nvidia) | marian-pritsak | added |
+|  | sonic-swss-maintainer | Stephen Wang(Google) | StephenWangGoogle | enabled |
+|  | sonic-swss-maintainer | Laveen Thamilchelvam (BRCM) | LaveenBrcm | Approved on 5/3/2023 and enabled |
+|  | sonic-swss-maintainer | Rajesh Sankaran (BRCM) | srj102 | Approved on 5/3/2023 and enabled |
+| sonic-swss-common | sonic-swss-common-maintainer | Qi Luo (Microsoft) | qiluo-msft | enabled |
+|  | sonic-swss-common-maintainer | Myron Sosyak (Intel) | msosyak | enabled |
+|  | sonic-swss-common-maintainer | Marian Pritsak (Nvidia) | marian-pritsak | enabled |
+|  | sonic-swss-common-maintainer | Runming Wu(Google) | mint570 | enabled |
+| sonic-gnmi (previously sonic-telemetry) | sonic-gnmi-maintainer | Qi Luo (Microsoft) | qiluo-msft | enabled |
+|  | sonic-gnmi-maintainer | Shashank Neelam | sneelam20 | Replace Tomek on 3/5/2024 |
+|  | sonic-gnmi-maintainer | Shishao (Alibaba) | shishao7sxm | invitation sent |
+|  | sonic-gnmi-maintainer | Seifert, Eric (DELL) | seiferteric | enabled |
+|  | sonic-gnmi-maintainer | Anand Subramanian (BRCM) | anand-kumar-subramanian | Approved on 5/3/2023 and enabled |
+| sonic-utilities | sonic-utilities-maintainer | Qi Luo (Microsoft) | qiluo-msft | enabled |
+| sonic-wpa-supplicant | sonic-wpa-supplicant-maintainer | Ze Gan (Microsoft) | Pterosaur | enabled |
+| sonic-buildimage | sonic-buildimage-maintainer | Guohan Lu (Microsoft) | lguohan | enabled |
+|  | sonic-buildimage-maintainer | Ying Xie (Microsoft) | yxieca | enabled |
+|  | sonic-buildimage-maintainer | Kumaresh Perumal (Microsoft) | kperumalbfn | enabled |
+|  | sonic-buildimage-maintainer | Don Newton (Intel) | donNewtonIntel | enabled |
+|  | sonic-buildimage-maintainer | Yilan Ji (Google) | baxia-lan | enabled |
+|  | sonic-buildimage-maintainer | Praveen Elagala (BRCM) | Praveen-Brcm | Approved on 5/3/2023 and enabled |
+|  | sonic-buildimage-maintainer | Prasanth Veettil (BRCM) | Prasanth-KV | Approved on 5/3/2023 and enabled |
+| sonic-mgmt | sonic-mgmt-maintainer | Ying Xie (Microsoft) | yxieca | enabled |
+|  | sonic-mgmt-maintainer | Bhavani Parise (Cisco) | bpar9 | enabled |
+|  | sonic-mgmt-maintainer | John Cheung (Intel) | johcheun | invitation sent |
+|  | sonic-mgmt-maintainer | Myron Sosyak (Intel) | msosyak | enabled |
+|  | sonic-mgmt-maintainer | Vamsi Punati(Google) | vamsipunati | invitation sent |
+|  | sonic-mgmt-maintainer | Sasthri Kristipati (BRCM) | ramakristipati | Approved on 5/3/2023 and enabled |
+| sonic-fips | sonic-fips-maintainer | Xuhui Miao (Microsoft) | xumia | enabled |
+| sonic-genl-packet | sonic-genl-packet-maintainer | Don Newton (Intel) | donNewtonIntel | enabled |
+| sonic-platform-vpp | sonic-platform-vpp-maintainer | Abdel Baig; Yue Gao (yuega2) | yue-fred-gaoabdbaig | enabled |
+|  | sonic-platform-vpp-maintainer | Bendrapu Balareddy (Cisco) | bendrapubalareddy | invitation sent |
+|  | sonic-platform-vpp-maintainer | Venkatesan Mahalingam (Dell) | venkatmahalingam | enabled |
+| sonic-dash-api | sonic-dash-api-maintainer | Ze Gan (Microsoft) | Pterosaur | enabled |
+| sonic-dash-ha | sonic-dash-ha-maintainer | Riff Jiang (Microsoft) | r12f |  |
+| sonic-bmp | sonic-bmp-maintainer | Qi Luo(Microsoft) | qiluo-msft | enabled |
+| sonic-host-services | sonic-host-services-maintainer | Qi Luo(Microsoft) | qiluo-msft |  |
+| sonic-formal-infra | sonic-formal-infra-maintainer | Mengqi Liu (Alibaba) | mengqiliu20 | enabled |
+|  | sonic-formal-infra-maintainer | Ali Kheradmand (Google) | kheradmandG |enabled  |


### PR DESCRIPTION
## Why
sonic-net/sonic-buildimage#28222 introduces a CODEOWNERS file that assigns ownership via GitHub maintainer teams. We need a nomination process for maintainers to join a specific github team as part of maintainer nominations. 

## How
Added a Team column in SONiC_Repo_Maintainer.md. For future nominations, people can post PRs adding rows to this table with the team specified
